### PR TITLE
capitalize requests.Session

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -22,7 +22,7 @@ class WrappedRequests(object):
     """
 
     def __init__(self):
-        self.session = real_requests.session()
+        self.session = real_requests.Session()
         if CacheControlAdapter:
             adapter = CacheControlAdapter(cache=FileCache(".webcache"))
             self.session.mount("http://", adapter)


### PR DESCRIPTION
`requests.session()` is deprecated. `requests.Session()` is the new hotness.
