### PR TITLE
feat: create changelogs tooling

### DIFF
--- a/edx_repo_tools/named-release-changelogs/README.rst
+++ b/edx_repo_tools/named-release-changelogs/README.rst
@@ -1,0 +1,28 @@
+CHANGELOGS FOR NAMED RELEASES
+############
+
+This directory has code to collect and sort commits which are the diff between a named edx-relase and the present.
+
+#. Create a Python 3.8 virtualenv.
+
+#. Install pygithub (https://github.com/PyGithub/PyGithub) into your virtualenv::
+
+   $ pip install pygithub
+
+#. Create html files of recent commit deltas with the following cli:
+
+   $ python python create_changelog.py
+
+#. required arguments. Note that an api token can be configured to give access to private and other repos.
+
+ $ -a GitHub API token (acquired here: https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+
+#. Optional arguments (default is ):
+
+   $ -i <branch>
+   $ -o <organization name ex: edx>
+   $ -r <repo to scrape commits from>
+
+#. Now you will be able to open a  html file created in the folder  titled {repo_name} changelog.html with your favorite browser
+
+Created for Hackathon XXVI: For the love of Docs

--- a/edx_repo_tools/named-release-changelogs/README.rst
+++ b/edx_repo_tools/named-release-changelogs/README.rst
@@ -11,7 +11,7 @@ This directory has code to collect and sort commits which are the diff between a
 
 #. Create html files of recent commit deltas with the following cli:
 
-   $ python python create_changelog.py
+   $ python create_changelog.py
 
 #. required arguments. Note that an api token can be configured to give access to private and other repos.
 

--- a/edx_repo_tools/named-release-changelogs/changelog_scripts.html
+++ b/edx_repo_tools/named-release-changelogs/changelog_scripts.html
@@ -1,0 +1,58 @@
+<input type="text" id="myInput" onkeyup="myFunction()" placeholder="Search for commits">
+<script>
+function myFunction() {
+  var input, filter, table, tr, td, i, txtValue;
+  input = document.getElementById("myInput");
+  filter = input.value.toUpperCase();
+  table = document.getElementById("myTable");
+  tr = table.getElementsByTagName("tr");
+  for (i = 0; i < tr.length; i++) {
+    td = tr[i].getElementsByTagName("td")[2];
+    if (td) {
+      txtValue = td.textContent || td.innerText;
+      if (txtValue.toUpperCase().indexOf(filter) > -1) {
+        tr[i].style.display = "";
+      } else {
+        tr[i].style.display = "none";
+      }
+    }
+  }
+}
+function sortTable(n) {
+  var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
+  table = document.getElementById("myTable");
+  switching = true;
+
+  dir = "asc";
+  while (switching) {
+    switching = false;
+    rows = table.rows;
+    for (i = 1; i < (rows.length - 1); i++) {
+      shouldSwitch = false;
+      x = rows[i].getElementsByTagName("TD")[n];
+      y = rows[i + 1].getElementsByTagName("TD")[n];
+      if (dir == "asc") {
+        if (x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()) {
+          shouldSwitch = true;
+          break;
+        }
+      } else if (dir == "desc") {
+        if (x.innerHTML.toLowerCase() < y.innerHTML.toLowerCase()) {
+          shouldSwitch = true;
+          break;
+        }
+      }
+    }
+    if (shouldSwitch) {
+      rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+      switching = true;
+      switchcount ++;
+    } else {
+      if (switchcount == 0 && dir == "asc") {
+        dir = "desc";
+        switching = true;
+      }
+    }
+  }
+}
+</script>

--- a/edx_repo_tools/named-release-changelogs/create_changelog.py
+++ b/edx_repo_tools/named-release-changelogs/create_changelog.py
@@ -1,0 +1,144 @@
+from github import Github, GithubException
+import requests
+import re
+import json
+import argparse
+
+
+# Initialize parser
+parser = argparse.ArgumentParser()
+
+# Adding optional argument
+parser.add_argument("-o", "--org", type=str,help = "Relevant Organization")
+parser.add_argument("-b", "--branch", type=str,help = "Relevant Named Release Branch")
+parser.add_argument("-r", "--repo", help = "edx REPO to parse")
+parser.add_argument("-a", "--api", help = "GITHUB API TOKEN")
+# Read arguments from command line
+args = parser.parse_args()
+
+ORGANIZATION = args.org or "edx"
+TOKEN = args.api
+
+g = Github(TOKEN, per_page =100)
+repo_name = (args.repo or "blockstore")
+repo = g.get_repo( ORGANIZATION+ "/"+ repo_name)
+
+def get_named_release_branches():
+
+    branch_names=list(repo.get_branches())
+    return list(filter(lambda branch: "open-release/" in branch.name, branch_names))
+
+def get_most_recent_named_release():
+    branches = get_named_release_branches()
+    return sorted(branches, reverse=True,key =lambda branch: repo.get_branch(branch.name).commit.commit.author.date)[0]
+
+def get_delta_commits():
+    print("Generating Commit Deltas")
+    most_recent= args.branch or get_most_recent_named_release().name
+    date = repo.get_branch(most_recent).commit.commit.author.date
+    commits = repo.get_commits(since=date)
+    return commits
+
+
+LAX= r"""(?xi) # case-insensitive
+    ^
+    # some labels can be pluralized, since it's hard to remember.
+    (?P<label>build|chores?|docs?|feat|fix|perf|refactor|revert|style|tests?|temp)
+    # an optional scope is allowed
+    (?:\(\w+\))?
+    (?P<breaking>!?):\s
+    (?P<subjtext>.+)
+    $
+    |
+    # GitHub revert PR commit syntax
+    ^Revert\s+"(?P<subjtext2>.+)"(?:\s+\(\#\d+\))?$
+    """
+
+def analyze_commit(title):
+    commit={}
+    commit["lax"] = False
+    m = re.search(LAX,title)
+    if m:
+        commit["lax"] = True
+        commit["label"]= m["label"]
+        commit["subjtext"]= m["subjtext"] or m["subjtext2"] or ""
+        if m["breaking"]:
+            commit["breaking"]= "YES"
+        else:
+            commit["breaking"]= ""
+    else:
+        commit["label"]= "other"
+        commit["subjtext"]= title
+        commit["breaking"]= ""
+    return commit
+
+def get_pr_url(commit):
+
+    request_dict = requests.get(
+        f'https://api.github.com/repos/{ORGANIZATION}/{repo_name}/commits/{commit.sha}/pulls',
+        headers= {
+            'Authorization': 'token %s' % TOKEN,
+            "Accept": "application/vnd.github.groot-preview+json"
+            }
+        ).text
+    try:
+        url =json.loads(request_dict)[0]["url"]
+    except:
+        try:
+            url= json.loads(request_dict)["url"]
+        except:
+            url= ""
+    return url
+
+def html_table(lol):
+  yield '<table id="myTable">'
+  yield'<tr><th onclick="sortTable(0)">Breaking</th> <th onclick="sortTable(1)">Label</th><th onclick="sortTable(2)">Title</th><th onclick="sortTable(3)">Date</th><th onclick="sortTable(4)">Author</th></tr>'
+  for sublist in lol:
+    yield '  <tr><td>'
+    yield '    </td><td>'.join(sublist)
+    yield '  </td></tr>'
+  yield '</table>'
+
+def create_changelog_html():
+    commits = get_delta_commits()
+    #TODO: ADD REAL COMMIT NAMES AND ORDER
+    filtered_commits=[]
+    print("Aquiring associated PRs")
+    for commit in commits:
+        title = commit.commit.message
+        #remove messaging for squashed merges
+        if title.split()[0]=="Merge":
+            title= " ".join(title.split()[8:])
+        title_info = analyze_commit(title[0:70])
+        pr_url= get_pr_url(commit)
+        filtered_commits.append(
+            [
+            title_info["breaking"],
+            title_info["label"],
+            title_info["subjtext"],
+            str(commit.commit.author.date),
+            f'<a href ="{commit.commit.author.email}">{commit.commit.author.name}</a>',
+            f'<a href ="{pr_url}">PR</a>',
+            ]
+        )
+
+    table_html = '\n'.join(html_table(filtered_commits))
+
+    with open('changelog_scripts.html', 'r') as file:
+        script_and_input = file.read().replace('\n', '')
+
+    msg = f'<!DOCTYPE html><html>{script_and_input}<body>{table_html}</body></html>'
+    text_file = open(f"{repo_name}changelog.html", "w")
+    text_file.write(msg)
+    text_file.close()
+
+create_changelog_html()
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
edx named releases (juniper, koa, maple, etc) require a changelog which captures important changes. We want changelogs to be curated by humans, for all the changes across openedx's repos. We want some tool to capture all the changes to be searchable and sortable, and in a format we can use later. 
-this tooling can be run outside of the repo, for any repo (not even edx ones) and captures the commits (and their PRs, if available) since the last or specified named release. For instance, you can find out "what changes to the build have we made to devstack since lilac" and get all the changes, and sort by commit type to see all the "build" conventional commits.
-an github api token is required to run this locally, directions to obtain such a token are included in the readme

A project for hackathon XXVI with the ethos of hackathon code (not pretty)