### PR TITLE
build: Dropped older node versions

### DIFF
--- a/edx_repo_tools/codemods/node16/gha_ci_modernizer.py
+++ b/edx_repo_tools/codemods/node16/gha_ci_modernizer.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 from edx_repo_tools.utils import YamlLoader
 
-ALLOWED_NODE_VERSIONS = [12, 14, 16]
+ALLOWED_NODE_VERSIONS = [16]
 ALLOWED_NPM_VERSION = '8.x.x'
 
 


### PR DESCRIPTION
We're going to deploy things on Node 16 now so updating the modernizer to drop support for older versions of Node