### PR TITLE
fix: github 404 in tag_release script

### DIFF
--- a/edx_repo_tools/oep2/explode_repos_yaml.py
+++ b/edx_repo_tools/oep2/explode_repos_yaml.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 
 @click.command()
 @pass_github
-@click.option('--org', multiple=True, default=['edx', 'edx-ops', 'edx-solutions',])
+@click.option('--org', multiple=True, default=['edx', 'edx-ops',])
 @click.option(
     '--branch',
     multiple=True,

--- a/edx_repo_tools/release/tag_release.py
+++ b/edx_repo_tools/release/tag_release.py
@@ -37,7 +37,7 @@ TOKEN_NAME = "openedx-release"
 
 # We are in the process of migrating repos; in the future, we will have to
 # remove "edx" from the list of organizations.
-OPENEDX_ORGS = ['edx', 'edx-solutions', 'openedx']
+OPENEDX_ORGS = ['edx', 'openedx']
 
 
 # An object to act like a response (with a .text attribute) in the case that


### PR DESCRIPTION
The edx-solutions organization no longer exists, and it causes a 404 error in
the tag_release script:

    tag_release --branch --dry open-release/nutmeg.master
    ...
    Traceback (most recent call last):
      File ".../repo-tools/.venv/bin/tag_release", line 33, in <module>
        sys.exit(load_entry_point('edx-repo-tools', 'console_scripts', 'tag_release')())
      File ".../repo-tools/.venv/lib/python3.9/site-packages/click/core.py", line 829, in __call__
        return self.main(*args, **kwargs)
      File ".../repo-tools/.venv/lib/python3.9/site-packages/click/core.py", line 782, in main
        rv = self.invoke(ctx)
      File ".../repo-tools/.venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
        return ctx.invoke(self.callback, **ctx.params)
      File ".../repo-tools/.venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
        return callback(*args, **kwargs)
      File ".../repo-tools/edx_repo_tools/auth.py", line 222, in wrapped
        f(hub=hub, *args, **kwargs)
      File ".../repo-tools/edx_repo_tools/release/tag_release.py", line 723, in main
        repos = openedx_release_repos(hub, orgs, branches)
      File ".../repo-tools/edx_repo_tools/release/tag_release.py", line 77, in openedx_release_repos
        for repo, data in tqdm(iter_openedx_yaml(hub, orgs=orgs, branches=branches), desc='Find repos'):
      File ".../repo-tools/.venv/lib/python3.9/site-packages/tqdm/std.py", line 1195, in __iter__
        for obj in iterable:
      File ".../repo-tools/edx_repo_tools/data.py", line 56, in iter_openedx_yaml
        for repo in iter_nonforks(hub, orgs):
      File ".../repo-tools/edx_repo_tools/data.py", line 32, in iter_nonforks
        for repo in hub.organization(org).repositories():
      File ".../repo-tools/.venv/lib/python3.9/site-packages/github3/github.py", line 1647, in organization
        json = self._json(self._get(url), 200)
      File ".../repo-tools/.venv/lib/python3.9/site-packages/github3/models.py", line 161, in _json
        raise exceptions.error_for(response)
    github3.exceptions.NotFoundError: 404 Not Found

To resolve this issue we simply get rid of the edx-solutions organization.