### PR TITLE
feat: read GITHUB_TOKEN env var for authentication

### DIFF
--- a/edx_repo_tools/auth.py
+++ b/edx_repo_tools/auth.py
@@ -195,11 +195,13 @@ def pass_github(f):
     @click.option(
         '--username',
         help='Specify the user to log in to GitHub with',
+        envvar="GITHUB_USERNAME",
     )
     @click.option('--password', help='Password to log in to GitHub with')
     @click.option(
         '--token',
         help='Personal access token to log in to GitHub with',
+        envvar="GITHUB_TOKEN",
     )
     @click.option(
         '--token-file',


### PR DESCRIPTION
I've been moving to having credentials in the environment rather than in
files on disk.  After deleting .netrc, repo-tools `clone_org` prompts
for a username and password.  This change lets it read a token from the
environment instead.