### PR TITLE
fix(conventional_commits): skip non-dir arguments

### DIFF
--- a/edx_repo_tools/conventional_commits/commitstats.py
+++ b/edx_repo_tools/conventional_commits/commitstats.py
@@ -119,6 +119,8 @@ def analyze_commit(row):
 def collect(dbfile, ignore, require, repos):
     db = dataset.connect("sqlite:///" + dbfile, sqlite_wal_mode=False)
     for repo in repos:
+        if not os.path.isdir(repo):
+            continue
         if any(fnmatch.fnmatch(repo, pat) for pat in ignore):
             print(f"Ignoring {repo}")
             continue


### PR DESCRIPTION
I use this line in a Makefile:
```
conventional_commits collect --ignore='*-private' edx/* openedx/*
```
Usually the openedx directory only has directories in it (cloned repos).  But I had a file in there at one point which stopped my command from working.  This fix will simply skip arguments that aren't directories.