### PR TITLE
fix: enable updating pip.txt in make upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(COMMON_CONSTRAINTS_TXT):
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -qr requirements/pip-tools.txt
-	pip-compile --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip install -qr requirements/pip.txt
 	pip install -qr requirements/pip-tools.txt

--- a/edx_repo_tools/conventional_commits/extra.txt
+++ b/edx_repo_tools/conventional_commits/extra.txt
@@ -53,7 +53,7 @@ pytz==2023.3
     # via pandas
 six==1.16.0
     # via python-dateutil
-sqlalchemy==1.4.47
+sqlalchemy==1.4.48
     # via
     #   alembic
     #   dataset

--- a/edx_repo_tools/find_dependencies/extra.txt
+++ b/edx_repo_tools/find_dependencies/extra.txt
@@ -16,9 +16,9 @@ mdurl==0.1.2
     # via markdown-it-py
 pygments==2.15.1
     # via rich
-requests==2.28.2
+requests==2.29.0
     # via -r edx_repo_tools/find_dependencies/extra.in
-rich==13.3.4
+rich==13.3.5
     # via -r edx_repo_tools/find_dependencies/extra.in
 typing-extensions==4.5.0
     # via rich

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -62,7 +62,7 @@ fissix==21.11.13
     # via bowler
 gitdb==4.0.10
     # via gitpython
-github3-py==4.0.0
+github3-py==4.0.1
     # via -r requirements/base.in
 gitpython==3.1.31
     # via -r requirements/base.in
@@ -121,7 +121,7 @@ path==16.6.0
     # via path-py
 path-py==12.5.0
     # via -r requirements/base.in
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -164,7 +164,7 @@ pyyaml==6.0
     # via -r requirements/base.in
 queuelib==1.6.2
     # via scrapy
-requests==2.28.2
+requests==2.29.0
     # via
     #   -r requirements/base.in
     #   cachecontrol
@@ -178,9 +178,9 @@ requests-file==1.5.1
     # via tldextract
 requests-oauthlib==1.3.1
     # via jira
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via jira
-ruamel-yaml==0.17.21
+ruamel-yaml==0.17.22
     # via -r requirements/base.in
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -201,7 +201,7 @@ smmap==5.0.0
     # via gitdb
 statistics==1.0.3.5
     # via -r requirements/base.in
-tldextract==3.4.0
+tldextract==3.4.1
     # via scrapy
 tlslite==0.4.9
     # via jira
@@ -227,7 +227,7 @@ urllib3==1.26.15
     # via requests
 urlobject==2.4.3
     # via -r requirements/base.in
-virtualenv==20.22.0
+virtualenv==20.23.0
     # via tox
 volatile==2.1.0
     # via bowler

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -106,7 +106,7 @@ gitdb==4.0.10
     # via
     #   -r requirements/base.txt
     #   gitpython
-github3-py==4.0.0
+github3-py==4.0.1
     # via -r requirements/base.txt
 gitpython==3.1.31
     # via -r requirements/base.txt
@@ -204,7 +204,7 @@ pep8==1.7.1
     # via -r requirements/development.in
 pip-tools==6.13.0
     # via -r requirements/development.in
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -292,7 +292,7 @@ queuelib==1.6.2
     # via
     #   -r requirements/base.txt
     #   scrapy
-requests==2.28.2
+requests==2.29.0
     # via
     #   -r requirements/base.txt
     #   cachecontrol
@@ -311,13 +311,13 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   jira
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via
     #   -r requirements/base.txt
     #   jira
 responses==0.23.1
     # via -r requirements/development.in
-ruamel-yaml==0.17.21
+ruamel-yaml==0.17.22
     # via -r requirements/base.txt
 ruamel-yaml-clib==0.2.7
     # via
@@ -350,7 +350,7 @@ stevedore==5.0.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-tldextract==3.4.0
+tldextract==3.4.1
     # via
     #   -r requirements/base.txt
     #   scrapy
@@ -366,7 +366,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
 tox==3.28.0
     # via
@@ -397,7 +397,7 @@ urllib3==1.26.15
     #   responses
 urlobject==2.4.3
     # via -r requirements/base.txt
-virtualenv==20.22.0
+virtualenv==20.23.0
     # via
     #   -r requirements/base.txt
     #   tox

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.37.1
+wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1.2
+pip==23.1.2
     # via -r requirements/pip.in
-setuptools==59.8.0
+setuptools==67.7.2
     # via -r requirements/pip.in


### PR DESCRIPTION
## Description
- `pip.txt` wasn't being updated in the `make upgrade` job because the `--upgrade` flag was missing in the `pip-compile` command
- It was causing the scheduled `Python Requirements Upgrade` [build](https://github.com/openedx/edx-django-utils/actions/runs/4847705622/jobs/8666288926#step:5:28) to fail due to `pip & pip-tools` conflict.