### PR TITLE
feat: rename universal triage team to openedx-triage

### DIFF
--- a/edx_repo_tools/repo_checks/repo_checks.py
+++ b/edx_repo_tools/repo_checks/repo_checks.py
@@ -4,6 +4,10 @@
 Run checks against repos and correct them if they're missing something.
 
 See README.rst in this directory for details.
+
+This script was originally developed in the terraform-github repository.
+If you're trying to git-blame it, you might need to dig into the original source:
+https://github.com/openedx-unsupported/terraform-github/blame/main/migrate/repo_checks.py
 """
 from __future__ import annotations
 
@@ -387,8 +391,7 @@ class EnsureWorkflowTemplates(Check):
             steps.append("No PR exists, creating a PR.")
             pr_body = textwrap.dedent(
                 """
-                This PR was created automatically by the `repo_checks.py` script in the
-                https://github.com/openedx/terraform-github repository.
+                This PR was created automatically by [the `repo_checks` tool](https://github.com/openedx/repo-tools/tree/master/edx_repo_tools/repo_checks).
                 """
             )
             if not dry_run:
@@ -601,15 +604,11 @@ class RequireTeamPermission(Check):
 
 class RequireTriageTeamAccess(RequireTeamPermission):
     """
-    The Core Contributor Triage Team needs to be able to triage
-    issues in all repos in the Open edX Platform.
-
-    The check function will tell us if the team has the correct level of access
-    and the fix function will make it so if it does not.
+    Ensure that the openedx-triage team grants Triage access to every public repo in the org.
     """
 
     def __init__(self, api, org, repo):
-        team = "community-pr-triage-managers"
+        team = "openedx-triage"
         permission = "triage"
         super().__init__(api, org, repo, team, permission)
 

--- a/edx_repo_tools/repo_checks/repo_checks.py
+++ b/edx_repo_tools/repo_checks/repo_checks.py
@@ -617,22 +617,6 @@ class RequireTriageTeamAccess(RequireTeamPermission):
         return is_public(self.api, self.org_name, self.repo_name)
 
 
-class RequireProductManagersAccess(RequireTeamPermission):
-    """
-    The Open edX Product Managers team needs to be able to triage issue
-    in all repos of the Open edX Platform.
-    """
-
-    def __init__(self, api, org, repo):
-        team = "open-edx-product-managers"
-        permission = "triage"
-        super().__init__(api, org, repo, team, permission)
-
-    def is_relevant(self):
-        # Need to be a public repo.
-        return is_public(self.api, self.org_name, self.repo_name)
-
-
 class RequiredCLACheck(Check):
     """
     This class validates the following:
@@ -900,7 +884,6 @@ class RequiredCLACheck(Check):
 CHECKS = [
     RequiredCLACheck,
     RequireTriageTeamAccess,
-    RequireProductManagersAccess,
     EnsureLabels,
     EnsureWorkflowTemplates,
 ]


### PR DESCRIPTION
### Description

Formerly, the universal triage team was named `community-pr-triage`.

Axim decided that we'd like to grant triage access to everyone in the org, not just PR triagers.
So, we choose the name `openedx-triage`, per https://openedx.atlassian.net/wiki/spaces/COMM/pages/3555852316/GitHub+Team+Naming+Conventions

Other small changes:
* docs: link to original terraform-github source in docstring
* fix: generated PRs should link here, not terraform-github

### After merging

* Rename the team in the GitHub UI
* Run `repo_checks -c RequireTriageTeamAccess` to ensure it's a no-op.
* Either:
  * Open an issue for adding a new type of check (a `TeamCheck`??) which would ensure that every org member is on the team, automatically.
  * Go the manual route:
    * add everyone to openedx-triage by hand
    * update our process docs to include adding new org members to openedx-triage