### PR TITLE
build: pin alembic to avoid a dataset bug

### DIFF
--- a/edx_repo_tools/conventional_commits/extra.txt
+++ b/edx_repo_tools/conventional_commits/extra.txt
@@ -4,8 +4,10 @@
 #
 #    make upgrade
 #
-alembic==1.11.1
-    # via dataset
+alembic==1.10.4
+    # via
+    #   -c edx_repo_tools/conventional_commits/../../requirements/constraints.txt
+    #   dataset
 banal==1.0.6
     # via dataset
 contourpy==1.1.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,1 +1,4 @@
 -c common_constraints.txt
+
+# dataset isn't compatible with alembic 1.11: https://github.com/pudo/dataset/issues/419
+alembic<1.11


### PR DESCRIPTION
The bug report: https://github.com/pudo/dataset/issues/419

Without the pin, this error happens when running this command:

```
$ conventional_commits collect --ignore='*-private' edx/* openedx/*
Traceback (most recent call last):
  File "/usr/local/virtualenvs/repo-tools/bin/conventional_commits", line 33, in <module>
    sys.exit(load_entry_point('edx-repo-tools', 'console_scripts', 'conventional_commits')())
  File "/usr/local/virtualenvs/repo-tools/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/virtualenvs/repo-tools/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/virtualenvs/repo-tools/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/virtualenvs/repo-tools/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/virtualenvs/repo-tools/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/System/Volumes/Data/root/src/edx/src/repo-tools/edx_repo_tools/conventional_commits/commitstats.py", line 134, in collect
    load_commits(db, repo_name)
  File "/System/Volumes/Data/root/src/edx/src/repo-tools/edx_repo_tools/conventional_commits/commitstats.py", line 71, in load_commits
    commit_table.insert(row)
  File "/usr/local/virtualenvs/repo-tools/lib/python3.8/site-packages/dataset/table.py", line 118, in insert
    row = self._sync_columns(row, ensure, types=types)
  File "/usr/local/virtualenvs/repo-tools/lib/python3.8/site-packages/dataset/table.py", line 381, in _sync_columns
    self._sync_table(sync_columns.values())
  File "/usr/local/virtualenvs/repo-tools/lib/python3.8/site-packages/dataset/table.py", line 356, in _sync_table
    self.db.op.add_column(self.name, column, self.db.schema)
TypeError: add_column() takes 3 positional arguments but 4 were given
```