### PR TITLE
fix(find_dependencies): use any github repo project-url if need be

### DIFF
--- a/edx_repo_tools/find_dependencies/find_dependencies.py
+++ b/edx_repo_tools/find_dependencies/find_dependencies.py
@@ -241,9 +241,12 @@ def repo_url_from_tgz(tgz_path: str) -> Optional[str]:
 
 
 SOURCE_URL_REGEXES = [
+    # These regexes are tried in order. The first group is the extracted URL.
     r"(?i)^Project-URL: Source.*,\s*(.*)$",
     r"(?i)^Home-page: (.*)$",
     r"(?i)^Project-URL: Home.*,\s*(.*)$",
+    # If we can't find a URL marked as home, then use any GitHub repo URL.
+    r"(?i)^Project-URL: [^,]+,\s*(https?://github.com/[^/]+/[^/]+)$",
 ]
 
 def repo_url_from_metadata(filename, metadata):


### PR DESCRIPTION
When looking for the GitHub home of a PyPI package, if nothing is explicitly marked as Source or Home, use any Project-URL that is a GitHub repo.

This doesn't find us any more repos, but removes this noise line from the output:

```
No repo URL in files/shapely-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl
```