### PR TITLE
Update BTR release scripts to look at catalog-info.yaml for release info.#439

### DIFF
--- a/edx_repo_tools/data.py
+++ b/edx_repo_tools/data.py
@@ -28,7 +28,7 @@ def iter_nonforks(hub, orgs):
                 yield repo
 
 
-def iter_openedx_yaml(hub, orgs, branches=None):
+def iter_openedx_yaml(filename, hub, orgs, branches=None):
     """
     Yield the data from all openedx.yaml files found in repositories in ``orgs``
     on any of ``branches``.
@@ -48,16 +48,16 @@ def iter_openedx_yaml(hub, orgs, branches=None):
     for repo in iter_nonforks(hub, orgs):
         for branch in (branches or [repo.default_branch]):
             try:
-                contents = repo.file_contents(OPEN_EDX_YAML, ref=branch)
+                contents = repo.file_contents(filename, ref=branch)
             except NotFoundError:
                 contents = None
 
             if contents is not None:
-                LOGGER.debug("Found openedx.yaml at %s:%s", repo.full_name, branch)
+                LOGGER.debug("Found %s at %s:%s", filename, repo.full_name, branch)
                 try:
                     data = yaml.safe_load(contents.decoded)
                 except Exception as exc:
-                    LOGGER.error("Couldn't parse openedx.yaml from %s:%s, skipping repo", repo.full_name, branch, exc_info=True)
+                    LOGGER.error("Couldn't parse %s from %s:%s, skipping repo", filename, repo.full_name, branch, exc_info=True)
                 else:
                     if data is not None:
                         yield repo, data


### PR DESCRIPTION
**Description:** 

In this PR i updated the BTR release script which was previously checking `openedx.yaml` file to find the `openedx-release `tag and performing other release preparation operations, now the updated script first check the catalog_info.yaml file in all repositories and in case that file is not present it checks for openedx.yaml.  I also tried to update some test cases related to it.

Ticket: https://github.com/orgs/openedx/projects/55/views/1?pane=issue&itemId=37975469