### PR TITLE
fix: catalog only repos are missing in a release list

### DIFF
--- a/edx_repo_tools/release/tag_release.py
+++ b/edx_repo_tools/release/tag_release.py
@@ -68,6 +68,10 @@ def filter_repos(openedx_repo, catalog_repo):
         else:
             result_dict[repo_key] = openedx_data 
 
+    for repo_key, catalog_data in catalog_repo.items():
+        if repo_key not in result_dict:
+            result_dict[repo_key] = catalog_data
+
     return result_dict        
 
  


### PR DESCRIPTION
Repositories that contain only the catalog-info.yaml file are missing from the result list.

Result with this fix:
```
Find commits  45/45
```

Result w/o the fix:
```
Find commits 37/37
```
