### PR TITLE
fix: use default branch when openedx.org/release annotation is empty

### DIFF
--- a/edx_repo_tools/release/tag_release.py
+++ b/edx_repo_tools/release/tag_release.py
@@ -100,8 +100,15 @@ def openedx_repos_with_catalog_info(hub, orgs=None, branches=None):
             annotations = data['metadata'].get('annotations')
             if annotations:
                 # Check if 'openedx.org/release' is present in annotations
-                if 'openedx.org/release' in annotations:
+                release_annotation = 'openedx.org/release'
+
+                if release_annotation in annotations:
                     repo = repo.refresh()
+
+                    # Defaulting to the repo's default branch
+                    if not annotations.get(release_annotation, None):
+                        annotations['openedx.org/release'] = repo.default_branch
+
                     repos[repo] = data
 
     return repos


### PR DESCRIPTION
The bug is hard to detect.

The tool shows the correct count of repos to be cut but the result list lacks repos with `null` values in `openedx.org/release` annotation.
```
Find commits  : 100%|█████████████████████████| 45/45 [00:33<00:00,  1.36it/s]
```

Without the fix (41):
```
openedx/aspects-dbt
openedx/course-discovery
openedx/credentials
openedx/cs_comments_service
openedx/docs.openedx.org
openedx/ecommerce-worker
openedx/ecommerce
openedx/edx-documentation
openedx/edx-notes-api
openedx/edx-platform
openedx/enterprise-access
openedx/enterprise-catalog
openedx/enterprise-subsidy
openedx/event-bus-redis
openedx/frontend-app-account
openedx/frontend-app-authn
openedx/frontend-app-communications
openedx/frontend-app-course-authoring
openedx/frontend-app-discussions
openedx/frontend-app-ecommerce
openedx/frontend-app-gradebook
openedx/frontend-app-learner-dashboard
openedx/frontend-app-learner-record
openedx/frontend-app-learning
openedx/frontend-app-ora-grading
openedx/frontend-app-ora
openedx/frontend-app-payment
openedx/frontend-app-profile
openedx/frontend-app-publisher
openedx/frontend-app-support-tools
openedx/frontend-plugin-framework
openedx/license-manager
openedx/openedx-app-android
openedx/openedx-app-ios
openedx/openedx-demo-course
openedx/openedx-test-course
openedx/platform-plugin-aspects
openedx/testeng-ci
openedx/tutor-contrib-aspects
openedx/xblock-skill-tagging
openedx/xqueue
```

With fix (45):
```
openedx/aspects-dbt
openedx/axim-engineering
openedx/course-discovery
openedx/credentials
openedx/cs_comments_service
openedx/docs.openedx.org
openedx/ecommerce-worker
openedx/ecommerce
openedx/edx-documentation
openedx/edx-lint
openedx/edx-notes-api
openedx/edx-platform
openedx/enterprise-access
openedx/enterprise-catalog
openedx/enterprise-subsidy
openedx/event-bus-redis
openedx/frontend-app-account
openedx/frontend-app-authn
openedx/frontend-app-communications
openedx/frontend-app-course-authoring
openedx/frontend-app-discussions
openedx/frontend-app-ecommerce
openedx/frontend-app-gradebook
openedx/frontend-app-learner-dashboard
openedx/frontend-app-learner-record
openedx/frontend-app-learning
openedx/frontend-app-ora-grading
openedx/frontend-app-ora
openedx/frontend-app-payment
openedx/frontend-app-profile
openedx/frontend-app-publisher
openedx/frontend-app-support-tools
openedx/frontend-plugin-framework
openedx/frontend-template-application
openedx/license-manager
openedx/openedx-app-android
openedx/openedx-app-ios
openedx/openedx-demo-course
openedx/openedx-test-course
openedx/platform-plugin-aspects
openedx/repo-tools
openedx/testeng-ci
openedx/tutor-contrib-aspects
openedx/xblock-skill-tagging
openedx/xqueue
```