### PR TITLE
build: Update codecov and use token

### DIFF
--- a/tests/fake_repos/repo_with_nvmrc/.github/workflows/release.yml
+++ b/tests/fake_repos/repo_with_nvmrc/.github/workflows/release.yml
@@ -27,7 +27,10 @@ jobs:
       - name: i18n_extract
         run: npm run i18n_extract
       - name: Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
       - name: Build
         run: npm run build
       - name: Release

--- a/tests/fake_repos/repo_without_nvmrc/.github/workflows/release.yml
+++ b/tests/fake_repos/repo_without_nvmrc/.github/workflows/release.yml
@@ -27,7 +27,10 @@ jobs:
       - name: i18n_extract
         run: npm run i18n_extract
       - name: Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
       - name: Build
         run: npm run build
       - name: Release

--- a/tests/sample_files/sample_ci_file_2.yml
+++ b/tests/sample_files/sample_ci_file_2.yml
@@ -46,7 +46,8 @@ jobs:
 
     - name: Run Coverage
       if: matrix.python-version == '3.8' && matrix.toxenv=='django42'
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         fail_ci_if_error: true

--- a/tests/sample_files/sample_node_ci.yml
+++ b/tests/sample_files/sample_node_ci.yml
@@ -37,7 +37,10 @@ jobs:
       run: npm run test
 
     - name: Run Coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
 
     - name: Send failure notification
       if: ${{ failure() }}

--- a/tests/sample_files/sample_node_ci2.yml
+++ b/tests/sample_files/sample_node_ci2.yml
@@ -42,4 +42,7 @@ jobs:
       run: npm run build
 
     - name: Run Coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true


### PR DESCRIPTION
Update codecov to the latest version and start using the org-wide token for uploads.

See https://github.com/openedx/wg-frontend/issues/179
