### PR TITLE
chore: barcalendar Redwood updates

### DIFF
--- a/barcalendar.py
+++ b/barcalendar.py
@@ -404,10 +404,10 @@ versions = get_defaults_from_tutor()
 # The current versions of everything.  Use the same strings as the keys in the various sections below.
 CURRENT = {
     "Open edX": parse_version_name(versions['OPENEDX_COMMON_VERSION']),
-    "Python": "3.8",
+    "Python": "3.11",
     "Django": "4.2",
     "Ubuntu": "20.04",
-    "Node": "16.x",
+    "Node": "18.x",
     "Mongo": parse_version_number(versions['DOCKER_IMAGE_MONGODB']),
     "MySQL": parse_version_number(versions['DOCKER_IMAGE_MYSQL']),
     "Elasticsearch": parse_version_number(versions['DOCKER_IMAGE_ELASTICSEARCH']),
@@ -416,10 +416,10 @@ CURRENT = {
 }
 
 EDX = {
-    "Python": "3.8",
+    "Python": "3.11",
     "Django": "4.2",
     "Ubuntu": "20.04",
-    "Node": "16.x",
+    "Node": "18.x",
     "Mongo": "4.2",
     "MySQL": "5.7",
     "Elasticsearch": "7.10",
@@ -454,9 +454,10 @@ names = [
     ("Olive", 2022, 12),
     ("Palm", 2023, 6),
     ("Quince", 2023, 12),
+    ("Redwood", 2024, 6),
     ]
 # https://www.treenames.net/common_tree_names.html
-future = ["Redwood", "Sumac", "Teak"] + list("UVWXYZ")
+future = ["Sumac", "Teak"] + list("UVWXYZ")
 target_length = 6 # months per release
 
 releases = list(itertools.chain(names, [(name, None, None) for name in future]))


### PR DESCRIPTION
Changes:
- removed Redwood from future releases
- changed CURRENT and EDX version of everything

@feanil I didn't change Mongo, MySQL, Elasticsearch, Redis, Ruby for EDX. I need an info about the current software versions for edx.org.
