### PR TITLE
fix: replace deprecated github actions

### DIFF
--- a/edx_repo_tools/pull_request_creator/__init__.py
+++ b/edx_repo_tools/pull_request_creator/__init__.py
@@ -619,7 +619,7 @@ class PullRequestCreator:
         if self.output_pr_url_for_github_action:
             # using print rather than logger to avoid the logger
             # prepending anything past which github actions wouldn't parse
-            print(f'::set-output name=generated_pr::https://github.com/{self.repository.full_name}/pull/{pr.number}')
+            print(f'generated_pr=https://github.com/{self.repository.full_name}/pull/{pr.number} >> $GITHUB_OUTPUT')
 
     def delete_old_pull_requests(self):
         logger.info("Checking if there's any old pull requests to delete")

--- a/tests/test_pull_request_creator.py
+++ b/tests/test_pull_request_creator.py
@@ -244,7 +244,7 @@ class UpgradePythonRequirementsPullRequestTestCase(TestCase):
         assert print_mock.call_count == 1
         found_matching_call = False
         for call in print_mock.call_args_list:
-            if '$GITHUB_OUTPUT' in call.args[0]:
+            if 'set-output' in call.args[0]:
                 found_matching_call = True
         assert found_matching_call
 

--- a/tests/test_pull_request_creator.py
+++ b/tests/test_pull_request_creator.py
@@ -244,7 +244,7 @@ class UpgradePythonRequirementsPullRequestTestCase(TestCase):
         assert print_mock.call_count == 1
         found_matching_call = False
         for call in print_mock.call_args_list:
-            if 'set-output' in call.args[0]:
+            if '$GITHUB_OUTPUT' in call.args[0]:
                 found_matching_call = True
         assert found_matching_call
 


### PR DESCRIPTION
## Description
- `set-output` has been deprecated by GitHub and it is suggested to be replaced by GitHub.