### PR TITLE
Rename and decorate repo checks

### DIFF
--- a/edx_repo_tools/repo_checks/repo_checks.py
+++ b/edx_repo_tools/repo_checks/repo_checks.py
@@ -168,7 +168,7 @@ class Check:
 
 
 @Check.register
-class EnsureRepoSettings(Check):
+class Settings(Check):
     """
     There are certain settings that we agree we want to be set a specific way on all repos.  This check
     will ensure that those settings are set correctly on all non-security repos.
@@ -257,7 +257,7 @@ class EnsureRepoSettings(Check):
 
 
 @Check.register
-class EnsureNoAdminOrMaintainTeams(Check):
+class NoAdminOrMaintainTeams(Check):
     """
     Teams should not be granted `admin` or `maintain` access to a repository unless the access
     is exceptional and it is noted here.  All other `admin` and `maintain` access is downgraded to
@@ -327,7 +327,7 @@ class EnsureNoAdminOrMaintainTeams(Check):
 
 
 @Check.register
-class EnsureWorkflowTemplates(Check):
+class Workflows(Check):
     """
     There are certain github action workflows that we to exist on all
     repos exactly as they are defined in the `.github` repo in the org.
@@ -613,7 +613,7 @@ class EnsureWorkflowTemplates(Check):
 
 
 @Check.register
-class EnsureLabels(Check):
+class Labels(Check):
     """
     All repos in the org should have certain labels.
     """
@@ -728,12 +728,12 @@ class EnsureLabels(Check):
         return simplified_label
 
 
-class RequireTeamPermission(Check):
+class TeamAccess(Check):
     """
     Require that a team has a certain level of access to a repository.
 
     To use this class as a check, create a subclass that specifies a particular
-    team and permission level, such as RequireTriageTeamAccess below.
+    team and permission level, such as TriageTeam below.
     """
 
     def __init__(self, api: GhApi, org: str, repo: str, team: str, permission: str):
@@ -802,7 +802,7 @@ class RequireTeamPermission(Check):
 
 
 @Check.register
-class RequireTriageTeamAccess(RequireTeamPermission):
+class TriageTeam(TeamAccess):
     """
     Ensure that the openedx-triage team grants Triage access to every public repo in the org.
     """
@@ -818,7 +818,7 @@ class RequireTriageTeamAccess(RequireTeamPermission):
 
 
 @Check.register
-class RequiredCLACheck(Check):
+class EnforceCLA(Check):
     """
     This class validates the following:
 
@@ -838,7 +838,7 @@ class RequiredCLACheck(Check):
         self.cla_team = "cla-checker"
         self.cla_team_permission = "push"
 
-        self.team_check = RequireTeamPermission(
+        self.team_check = TeamAccess(
             api,
             org,
             repo,
@@ -1079,7 +1079,7 @@ class RequiredCLACheck(Check):
 
 
 @Check.register
-class EnsureNoDirectRepoAccessToUsers(Check):
+class NoDirectUsers(Check):
     """
     Users should not have direct repo access
     """

--- a/edx_repo_tools/repo_checks/repo_checks.py
+++ b/edx_repo_tools/repo_checks/repo_checks.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import importlib.resources
 import re
 import textwrap
-from functools import lru_cache
+from functools import cache
 from itertools import chain
 from pprint import pformat
 
@@ -36,11 +36,6 @@ from ghapi.all import GhApi, paged
 HAS_GHSA_SUFFIX = re.compile(r".*?-ghsa-\w{4}-\w{4}-\w{4}$")
 
 LABELS_YAML_FILENAME = "./labels.yaml"
-
-# Note: This is functionally equivalent to `from functools import cache`,
-# which becomes available in Python 3.9.
-# https://docs.python.org/3/library/functools.html#functools.cache
-cache = lru_cache(maxsize=None)
 
 
 def all_paged_items(func, *args, **kwargs):

--- a/tests/test_repo_checks.py
+++ b/tests/test_repo_checks.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from edx_repo_tools.repo_checks.repo_checks import EnsureLabels
+from edx_repo_tools.repo_checks import repo_checks
 
 
 @pytest.fixture
@@ -35,12 +35,12 @@ labels_yaml = [
 ]
 
 
-@patch.object(EnsureLabels, "labels", labels_yaml)
-class TestEnsureLabels:
+@patch.object(repo_checks.Labels, "labels", labels_yaml)
+class TestLabelsCheck:
     def test_check_for_no_change(self, maintenance_label):
         api = MagicMock()
         api.issues.list_labels_for_repo.side_effect = [[maintenance_label], None]
-        check_cls = EnsureLabels(api, "test_org", "test_repo")
+        check_cls = repo_checks.Labels(api, "test_org", "test_repo")
 
         # Make sure that the check returns True, indicating that no changes need to be made.
         assert check_cls.check()[0]
@@ -48,7 +48,7 @@ class TestEnsureLabels:
     def test_addition(self, maintenance_label):
         api = MagicMock()
         api.issues.list_labels_for_repo.return_value = []
-        check_cls = EnsureLabels(api, "test_org", "test_repo")
+        check_cls = repo_checks.Labels(api, "test_org", "test_repo")
 
         # The check should be false because the maintenance label should be missing.
         assert check_cls.check()[0] == False
@@ -72,7 +72,7 @@ class TestEnsureLabels:
         api = MagicMock()
         api.issues.list_labels_for_repo.side_effect = [[maintenance_label], None]
 
-        check_cls = EnsureLabels(api, "test_org", "test_repo")
+        check_cls = repo_checks.Labels(api, "test_org", "test_repo")
 
         assert check_cls.check()[0] == False
         check_cls.fix()


### PR DESCRIPTION
Rename teams to be a bit more consistent and brief.

Also, get rid of the hardcoded `CHECKS` list in exchange for a `@Check.register` decorator.

Before:
```
(venv) ~/openedx/repo-tools 🍀 repo_checks --help
Usage: repo_checks [OPTIONS]

  Entry point for command-line invocation.

Options:
  --github-token TEXT             A github personal access token.  [required]
  --org TEXT                      The github org that you wish check.
  -n, --dry-run / --no-dry-run    Show what changes would be made without
                                  making them.
  -c, --check [RequiredCLACheck|RequireTriageTeamAccess|EnsureLabels|EnsureWorkflowTemplates|EnsureNoAdminOrMaintainTeams|EnsureRepoSettings|EnsureNoDirectRepoAccessToUsers]
                                  Limit to specific check(s), case-
                                  insensitive.
  -r, --repo TEXT                 Limit to specific repo(s).
  -s, --start-at TEXT             Which repo in the list to start running
                                  checks at.
  --help                          Show this message and exit.
```

After:
```
(venv) ~/openedx/repo-tools 🍀 repo_checks --help
Usage: repo_checks [OPTIONS]

  Entry point for command-line invocation.

Options:
  --github-token TEXT             A github personal access token.  [required]
  --org TEXT                      The github org that you wish check.
  -n, --dry-run / --no-dry-run    Show what changes would be made without
                                  making them.
  -c, --check [Settings|NoAdminOrMaintainTeams|Workflows|Labels|TriageTeam|EnforceCLA|NoDirectUsers]
                                  Limit to specific check(s), case-
                                  insensitive.
  -r, --repo TEXT                 Limit to specific repo(s).
  -s, --start-at TEXT             Which repo in the list to start running
                                  checks at.
  --help                          Show this message and exit.

```