### PR TITLE
feat: add flaky-test label

### DIFF
--- a/edx_repo_tools/repo_checks/labels.yaml
+++ b/edx_repo_tools/repo_checks/labels.yaml
@@ -89,6 +89,10 @@
   color: "d93f0b"  # scarlet red...
   description: "Report of or fix for something that isn't working as intended"
 
+- name: "flaky-test"
+  color: "006b75"  # teal
+  description: "Details a test removed as part of the flaky test process" 
+
 - name: "discovery"
   color: "d876e3"  # a curious shade of lavendar
   description: "Pre-work to determine if an idea is feasible"


### PR DESCRIPTION
Add a flaky-test label to be used as part of an updated flaky test process. See:
https://openedx.atlassian.net/wiki/spaces/AC/pages/4306337795/Flaky+Test+Process

The original process used the old edX Jira project, and this update is a part of moving this process to github.