### PR TITLE
chore: Adds hactoberfest-accepted label

### DIFF
--- a/edx_repo_tools/repo_checks/labels.yaml
+++ b/edx_repo_tools/repo_checks/labels.yaml
@@ -41,6 +41,10 @@
   color: "54976d"  # fenway green
   description: "Ready to be picked up by anyone in the community"
 
+- name: "hacktoberfest-accepted"
+  color: "e2ba53"  # golden-yellow
+  description: "Issue accepted for hacktoberfest participants"
+
 
 ### LABELS INDICATING BROAD THEMES OF WORK.
 ### MORE THAN ONE OF THESE MAY APPLY AT A TIME.


### PR DESCRIPTION
chore: Adds hactoberfest-accepted label


This PR is adding `hactoberfest-accepted` label because Hacktober participant's PR/MRs must be in a repo tagged with the “hacktoberfest” topic, or have the “hacktoberfest-accepted” label.

For further information: https://hacktoberfest.com/participation/

