### PR TITLE
feat: Add a check to ensure the committers-at-large team has access.

### DIFF
--- a/edx_repo_tools/repo_checks/repo_checks.py
+++ b/edx_repo_tools/repo_checks/repo_checks.py
@@ -818,6 +818,22 @@ class TriageTeam(TeamAccess):
 
 
 @Check.register
+class MaintainersAtLargeTeam(TeamAccess):
+    """
+    Ensure that the committers-maintainers-at-large team grants Push access to every public repo in the org.
+    """
+
+    def __init__(self, api, org, repo):
+        team = "committers-maintainers-at-large"
+        permission = "push"
+        super().__init__(api, org, repo, team, permission)
+
+    def is_relevant(self):
+        # Need to be a public repo.
+        return is_public(self.api, self.org_name, self.repo_name)
+
+
+@Check.register
 class EnforceCLA(Check):
     """
     This class validates the following:


### PR DESCRIPTION
This tema should have write access to all public repos.  They can do any
maintenance work in any public repo that is a part of the Open edX
platform.
