### PR TITLE
fix: Compute diff properly in package home URL sets

### DIFF
--- a/edx_repo_tools/find_dependencies/find_python_dependencies.py
+++ b/edx_repo_tools/find_dependencies/find_python_dependencies.py
@@ -70,10 +70,10 @@ def main(directories=None, ignore_paths=None):
                 url = request_package_info_url(req.name)
                 if url is not None:
                     home_page.add(url)
-                    
+
     packages_urls = set(urls_in_orgs(home_page, SECOND_PARTY_ORGS))
-    
-    if diff:= packages_urls.symmetric_difference(set(ignore_paths)):
+
+    if diff := packages_urls - set(ignore_paths):
             print("The following packages are from 2nd party orgs and should not be added as a core dependency, they can be added as an optional dependency operationally or they can be transferred to the openedx org before they are included:")
             print("\n".join(diff))
             exit(1)


### PR DESCRIPTION
Using symmetric difference caused entries from the ignore list to be reported as 2nd party orgs in some cases. This appears to happen when the lookup fails for a package that matches something in the ignore list, and so its URL doesn't end up in `packages_urls`.

It's not clear what the nature of the failure is exactly (since we're not getting log messages about non-200 status codes) but we were seeing sporadic claims that `https://github.com/edx/codejail-includes` was found in the dependencies. The package on PyPI now actually is under the openedx org, so I believe this URL must have been coming from the ignore list.

We could add logging to discover what the failure mode is, but a lot of packages don't have a home URL, so it may not be simple to do this in a way that isn't noisy.