### PR TITLE
fix!: [DEPR] Cleanup New Relic Source Map Webpack Plugin

### DIFF
--- a/edx_repo_tools/find_dependencies/README.rst
+++ b/edx_repo_tools/find_dependencies/README.rst
@@ -373,7 +373,6 @@ https://github.com/edx/edx-name-affirmation
 https://github.com/edx/frontend-component-footer-edx
 https://github.com/edx/getsmarter-api-clients
 https://github.com/edx/learner-pathway-progress
-https://github.com/edx/new-relic-source-map-webpack-plugin
 https://github.com/edx/outcome-surveys
 https://github.com/edx/ux-pattern-library
 https://github.com/mitodl/edx-sga


### PR DESCRIPTION
Removed new-relic-source-map-webpack-plugin imports/requires from all webpack configuration files. Cleaned up plugin configurations and related code. Removed any associated New Relic source map upload functionality