### PR TITLE
build: remove arbi-bom label from support window issues

### DIFF
--- a/.github/workflows/support-window-issue-creator.yml
+++ b/.github/workflows/support-window-issue-creator.yml
@@ -14,7 +14,6 @@ jobs:
         uses: imjohnbo/issue-bot@v3
         with:
           assignees: "usamasadiq"
-          labels: "arbi-bom"
           close-previous: true
           title: "Support Window Update"
           body: |


### PR DESCRIPTION
## Description

- `arbi-bom` team is soon going to be removed so removing the label from the issue.
- I would like to keep the ownership of these issues to continue working as open source contributor in the community.