### PR TITLE
Remove deprecated repos from find_dependencies

### DIFF
--- a/edx_repo_tools/find_dependencies/README.rst
+++ b/edx_repo_tools/find_dependencies/README.rst
@@ -31,351 +31,349 @@ I run it in a tree of all repos, with these commands to examine all the repos br
 
 (gittreeif is from https://github.com/openedx/repo-tools/gittools.sh)
 
-It reports on its progress and failures, like this:
+It reports on its progress and failures, like this::
 
-```
-% find_dependencies $OLIVE_DIRS
-Creating new work directory: /tmp/unpack_reqs
--- /src/ghorg/openedx/DoneXBlock ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 12/12
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 12/12
--- /src/ghorg/openedx/blockstore ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 47/47
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 3/3
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 50/50
--- /src/ghorg/openedx/configuration ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 32/32
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 7/7
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 38/38
--- /src/ghorg/openedx/course-discovery ----------
-Checking JavaScript dependencies
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 391/391
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 317/317
-391 deps, 317 urls, 282 real urls
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
--- /src/ghorg/openedx/credentials ----------
-Checking JavaScript dependencies
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1000/1000
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 647/647
-1000 deps, 647 urls, 589 real urls
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 85/85
-Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 8/8
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 93/93
--- /src/ghorg/openedx/cs_comments_service ----------
--- /src/ghorg/openedx/devstack ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 25/25
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 2/2
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 27/27
--- /src/ghorg/openedx/docs.openedx.org ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-No repo URL in files/sphinx_book_theme-0.3.3-py3-none-any.whl
-No repo URL in files/pydata_sphinx_theme-0.8.1-py3-none-any.whl
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 34/34
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1/1
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 28/28
--- /src/ghorg/openedx/ecommerce ----------
-Checking JavaScript dependencies
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 713/713
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 612/612
-713 deps, 612 urls, 519 real urls
-Checking Python dependencies
-Creating venv
-Downloading packages
-Repo URL is UNKNOWN in files/python_toolbox-1.0.11-py2.py3-none-any.whl
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 151/151
-Repo URL is UNKNOWN in files/logger-1.4.tar.gz
-Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
-Repo URL is UNKNOWN in files/cybersource-rest-client-python-0.0.21.tar.gz
-Repo URL is UNKNOWN in files/pycountry-17.1.8.tar.gz
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 24/24
-ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x107ea7be0>, 'Connection to naked-py.com timed out. (connect timeout=60)'))
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 169/169
--- /src/ghorg/openedx/ecommerce-worker ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 25/25
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 2/2
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 27/27
--- /src/ghorg/openedx/edx-analytics-configuration ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 19/19
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1/1
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 19/19
--- /src/ghorg/openedx/edx-analytics-dashboard ----------
-Checking JavaScript dependencies
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1611/1611
-Couldn't fetch https://github.com:mafintosh/tar-fs: Failed to parse: https://github.com:mafintosh/tar-fs
-Couldn't fetch https://github.com:mafintosh/tar-stream: Failed to parse: https://github.com:mafintosh/tar-stream
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1173/1173
-1611 deps, 1173 urls, 931 real urls
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 62/62
-Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 8/8
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 68/68
--- /src/ghorg/openedx/edx-analytics-data-api ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 68/68
-Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 9/9
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 76/76
--- /src/ghorg/openedx/edx-analytics-pipeline ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
--- /src/ghorg/openedx/edx-app-android ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 9/9
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 10/10
--- /src/ghorg/openedx/edx-app-ios ----------
--- /src/ghorg/openedx/edx-developer-docs ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
--- /src/ghorg/openedx/edx-documentation ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 29/29
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1/1
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 25/25
--- /src/ghorg/openedx/edx-notes-api ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 52/52
-Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 5/5
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 56/56
--- /src/ghorg/openedx/edx-platform ----------
-Checking JavaScript dependencies
-edx-proctoring-proctortrack@1.1.1: https://registry.npmjs.org/edx-proctoring-proctortrack/1.1.1 -> 404
-edx@0.1.0: https://registry.npmjs.org/edx/0.1.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 2045/2045
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1393/1393
-2045 deps, 1393 urls, 1127 real urls
-Checking Python dependencies
-Creating venv
-Downloading packages
-Repo URL is UNKNOWN in files/pynliner-0.8.0-py2.py3-none-any.whl
-Repo URL is UNKNOWN in files/openedx_django_wiki-1.1.4-py3-none-any.whl
-No repo URL in files/click_didyoumean-0.3.0-py3-none-any.whl
-Repo URL is UNKNOWN in files/xblock_google_drive-0.3.0-py2.py3-none-any.whl
-Repo URL is UNKNOWN in files/xblock_drag_and_drop_v2-3.0.0-py3-none-any.whl
-Repo URL is UNKNOWN in files/edx_user_state_client-1.3.2-py3-none-any.whl
-Repo URL is UNKNOWN in files/done_xblock-2.0.4-py3-none-any.whl
-No repo URL in files/staff_graded_xblock-2.0.1-py3-none-any.whl
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 250/250
-Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 24/24
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 270/270
--- /src/ghorg/openedx/enterprise-access ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-No repo URL in files/click_didyoumean-0.3.0-py3-none-any.whl
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 88/88
-Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 8/8
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 94/94
--- /src/ghorg/openedx/enterprise-catalog ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-No repo URL in files/click_didyoumean-0.3.0-py3-none-any.whl
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 86/86
-Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 7/7
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 91/91
--- /src/ghorg/openedx/frontend-app-account ----------
-Checking JavaScript dependencies
-@edx/frontend-app-account@1.0.0-semantically-released: https://registry.npmjs.org/@edx/frontend-app-account/1.0.0-semantically-released -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1430/1430
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 911/911
-1430 deps, 911 urls, 824 real urls
--- /src/ghorg/openedx/frontend-app-authn ----------
-Checking JavaScript dependencies
-@edx/frontend-app-authn@0.1.0: https://registry.npmjs.org/@edx/frontend-app-authn/0.1.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1646/1646
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1044/1044
-1646 deps, 1044 urls, 934 real urls
--- /src/ghorg/openedx/frontend-app-communications ----------
-Checking JavaScript dependencies
-@edx/frontend-app-communications@0.1.0: https://registry.npmjs.org/@edx/frontend-app-communications/0.1.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1555/1555
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 967/967
-1555 deps, 967 urls, 868 real urls
--- /src/ghorg/openedx/frontend-app-course-authoring ----------
-Checking JavaScript dependencies
-@edx/frontend-app-course-authoring@0.1.0: https://registry.npmjs.org/@edx/frontend-app-course-authoring/0.1.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1629/1629
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1072/1072
-1629 deps, 1072 urls, 968 real urls
--- /src/ghorg/openedx/frontend-app-discussions ----------
-Checking JavaScript dependencies
-@edx/frontend-app-discussions@0.1.0: https://registry.npmjs.org/@edx/frontend-app-discussions/0.1.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1597/1597
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1010/1010
-1597 deps, 1010 urls, 912 real urls
--- /src/ghorg/openedx/frontend-app-ecommerce ----------
-Checking JavaScript dependencies
-@edx/frontend-app-ecommerce@0.1.0: https://registry.npmjs.org/@edx/frontend-app-ecommerce/0.1.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1695/1695
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1122/1122
-1695 deps, 1122 urls, 1006 real urls
--- /src/ghorg/openedx/frontend-app-gradebook ----------
-Checking JavaScript dependencies
-@edx/frontend-app-gradebook@1.6.0: https://registry.npmjs.org/@edx/frontend-app-gradebook/1.6.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1980/1980
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1273/1273
-1980 deps, 1273 urls, 1118 real urls
--- /src/ghorg/openedx/frontend-app-learner-dashboard ----------
-Checking JavaScript dependencies
-@edx/frontend-component-footer@1.0.0-semantically-released: https://registry.npmjs.org/@edx/frontend-component-footer/1.0.0-semantically-released -> 404
-@edx/frontend-app-learner-dashboard@0.0.1: https://registry.npmjs.org/@edx/frontend-app-learner-dashboard/0.0.1 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1917/1917
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1279/1279
-1917 deps, 1279 urls, 1148 real urls
--- /src/ghorg/openedx/frontend-app-learner-record ----------
-Checking JavaScript dependencies
-@edx/frontend-app-learner-record@0.1.0: https://registry.npmjs.org/@edx/frontend-app-learner-record/0.1.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1527/1527
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 952/952
-1527 deps, 952 urls, 866 real urls
--- /src/ghorg/openedx/frontend-app-learning ----------
-Checking JavaScript dependencies
-@edx/frontend-app-learning@1.0.0-semantically-released: https://registry.npmjs.org/@edx/frontend-app-learning/1.0.0-semantically-released -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1712/1712
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1073/1073
-1712 deps, 1073 urls, 861 real urls
--- /src/ghorg/openedx/frontend-app-ora-grading ----------
-Checking JavaScript dependencies
-@edx/frontend-app-ora-grading@0.0.1: https://registry.npmjs.org/@edx/frontend-app-ora-grading/0.0.1 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1902/1902
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1234/1234
-1902 deps, 1234 urls, 1115 real urls
--- /src/ghorg/openedx/frontend-app-payment ----------
-Checking JavaScript dependencies
-@edx/frontend-app-payment@0.1.0: https://registry.npmjs.org/@edx/frontend-app-payment/0.1.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1518/1518
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 989/989
-1518 deps, 989 urls, 904 real urls
--- /src/ghorg/openedx/frontend-app-profile ----------
-Checking JavaScript dependencies
-@edx/frontend-app-profile@1.0.0-semantically-released: https://registry.npmjs.org/@edx/frontend-app-profile/1.0.0-semantically-released -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1575/1575
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1013/1013
-1575 deps, 1013 urls, 923 real urls
--- /src/ghorg/openedx/frontend-app-publisher ----------
-Checking JavaScript dependencies
-edx-frontend-app-publisher@0.1.0: https://registry.npmjs.org/edx-frontend-app-publisher/0.1.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1616/1616
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1071/1071
-1616 deps, 1071 urls, 952 real urls
--- /src/ghorg/openedx/frontend-app-support-tools ----------
-Checking JavaScript dependencies
-@edx/frontend-app-support@0.1.0: https://registry.npmjs.org/@edx/frontend-app-support/0.1.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1683/1683
-Couldn't fetch github.com:samccone/chrome-trace-event: No connection adapters were found for 'github.com:samccone/chrome-trace-event'
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1150/1150
-1683 deps, 1150 urls, 994 real urls
--- /src/ghorg/openedx/frontend-template-application ----------
-Checking JavaScript dependencies
-@edx/frontend-template-application@0.1.0: https://registry.npmjs.org/@edx/frontend-template-application/0.1.0 -> 404
-Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1378/1378
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 851/851
-1378 deps, 851 urls, 782 real urls
--- /src/ghorg/openedx/license-manager ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-No repo URL in files/click_didyoumean-0.3.0-py3-none-any.whl
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 89/89
-Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 9/9
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 96/96
--- /src/ghorg/openedx/openedx-demo-course ----------
--- /src/ghorg/openedx/openedx-test-course ----------
--- /src/ghorg/openedx/repo-tools ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 82/82
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 6/6
-Couldn't fetch http://trevp.net/tlslite/: ('Connection aborted.', ConnectionResetError(54, 'Connection reset by peer'))
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 87/87
--- /src/ghorg/openedx/testeng-ci ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 20/20
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1/1
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 21/21
--- /src/ghorg/openedx/tubular ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 62/62
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 13/13
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 75/75
--- /src/ghorg/openedx/xqueue ----------
-Checking Python dependencies
-Creating venv
-Downloading packages
-Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 34/34
-Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 2/2
-Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 36/36
-== DONE ==============
-Second-party:
-https://github.com/edx/brand-edx.org
-https://github.com/edx/braze-client
-https://github.com/edx/edx-name-affirmation
-https://github.com/edx/frontend-component-footer-edx
-https://github.com/edx/getsmarter-api-clients
-https://github.com/edx/learner-pathway-progress
-https://github.com/edx/new-relic-source-map-webpack-plugin
-https://github.com/edx/outcome-surveys
-https://github.com/edx/ux-pattern-library
-https://github.com/mitodl/edx-sga
-https://github.com/open-craft/xblock-poll
-```
+    % find_dependencies $OLIVE_DIRS
+    Creating new work directory: /tmp/unpack_reqs
+    -- /src/ghorg/openedx/DoneXBlock ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 12/12
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 12/12
+    -- /src/ghorg/openedx/blockstore ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 47/47
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 3/3
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 50/50
+    -- /src/ghorg/openedx/configuration ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 32/32
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 7/7
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 38/38
+    -- /src/ghorg/openedx/course-discovery ----------
+    Checking JavaScript dependencies
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 391/391
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 317/317
+    391 deps, 317 urls, 282 real urls
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
+    -- /src/ghorg/openedx/credentials ----------
+    Checking JavaScript dependencies
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1000/1000
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 647/647
+    1000 deps, 647 urls, 589 real urls
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 85/85
+    Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 8/8
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 93/93
+    -- /src/ghorg/openedx/cs_comments_service ----------
+    -- /src/ghorg/openedx/devstack ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 25/25
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 2/2
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 27/27
+    -- /src/ghorg/openedx/docs.openedx.org ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    No repo URL in files/sphinx_book_theme-0.3.3-py3-none-any.whl
+    No repo URL in files/pydata_sphinx_theme-0.8.1-py3-none-any.whl
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 34/34
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1/1
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 28/28
+    -- /src/ghorg/openedx/ecommerce ----------
+    Checking JavaScript dependencies
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 713/713
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 612/612
+    713 deps, 612 urls, 519 real urls
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Repo URL is UNKNOWN in files/python_toolbox-1.0.11-py2.py3-none-any.whl
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 151/151
+    Repo URL is UNKNOWN in files/logger-1.4.tar.gz
+    Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
+    Repo URL is UNKNOWN in files/cybersource-rest-client-python-0.0.21.tar.gz
+    Repo URL is UNKNOWN in files/pycountry-17.1.8.tar.gz
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 24/24
+    ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x107ea7be0>, 'Connection to naked-py.com timed out. (connect timeout=60)'))
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 169/169
+    -- /src/ghorg/openedx/ecommerce-worker ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 25/25
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 2/2
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 27/27
+    -- /src/ghorg/openedx/edx-analytics-configuration ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 19/19
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1/1
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 19/19
+    -- /src/ghorg/openedx/edx-analytics-dashboard ----------
+    Checking JavaScript dependencies
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1611/1611
+    Couldn't fetch https://github.com:mafintosh/tar-fs: Failed to parse: https://github.com:mafintosh/tar-fs
+    Couldn't fetch https://github.com:mafintosh/tar-stream: Failed to parse: https://github.com:mafintosh/tar-stream
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1173/1173
+    1611 deps, 1173 urls, 931 real urls
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 62/62
+    Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 8/8
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 68/68
+    -- /src/ghorg/openedx/edx-analytics-data-api ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 68/68
+    Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 9/9
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 76/76
+    -- /src/ghorg/openedx/edx-analytics-pipeline ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
+    -- /src/ghorg/openedx/edx-app-android ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 9/9
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 10/10
+    -- /src/ghorg/openedx/edx-app-ios ----------
+    -- /src/ghorg/openedx/edx-developer-docs ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0/0
+    -- /src/ghorg/openedx/edx-documentation ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 29/29
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1/1
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 25/25
+    -- /src/ghorg/openedx/edx-notes-api ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 52/52
+    Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 5/5
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 56/56
+    -- /src/ghorg/openedx/edx-platform ----------
+    Checking JavaScript dependencies
+    edx-proctoring-proctortrack@1.1.1: https://registry.npmjs.org/edx-proctoring-proctortrack/1.1.1 -> 404
+    edx@0.1.0: https://registry.npmjs.org/edx/0.1.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 2045/2045
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1393/1393
+    2045 deps, 1393 urls, 1127 real urls
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Repo URL is UNKNOWN in files/pynliner-0.8.0-py2.py3-none-any.whl
+    Repo URL is UNKNOWN in files/openedx_django_wiki-1.1.4-py3-none-any.whl
+    No repo URL in files/click_didyoumean-0.3.0-py3-none-any.whl
+    Repo URL is UNKNOWN in files/xblock_google_drive-0.3.0-py2.py3-none-any.whl
+    Repo URL is UNKNOWN in files/xblock_drag_and_drop_v2-3.0.0-py3-none-any.whl
+    Repo URL is UNKNOWN in files/edx_user_state_client-1.3.2-py3-none-any.whl
+    Repo URL is UNKNOWN in files/done_xblock-2.0.4-py3-none-any.whl
+    No repo URL in files/staff_graded_xblock-2.0.1-py3-none-any.whl
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 250/250
+    Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 24/24
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 270/270
+    -- /src/ghorg/openedx/enterprise-access ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    No repo URL in files/click_didyoumean-0.3.0-py3-none-any.whl
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 88/88
+    Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 8/8
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 94/94
+    -- /src/ghorg/openedx/enterprise-catalog ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    No repo URL in files/click_didyoumean-0.3.0-py3-none-any.whl
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 86/86
+    Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 7/7
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 91/91
+    -- /src/ghorg/openedx/frontend-app-account ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-account@1.0.0-semantically-released: https://registry.npmjs.org/@edx/frontend-app-account/1.0.0-semantically-released -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1430/1430
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 911/911
+    1430 deps, 911 urls, 824 real urls
+    -- /src/ghorg/openedx/frontend-app-authn ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-authn@0.1.0: https://registry.npmjs.org/@edx/frontend-app-authn/0.1.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1646/1646
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1044/1044
+    1646 deps, 1044 urls, 934 real urls
+    -- /src/ghorg/openedx/frontend-app-communications ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-communications@0.1.0: https://registry.npmjs.org/@edx/frontend-app-communications/0.1.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1555/1555
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 967/967
+    1555 deps, 967 urls, 868 real urls
+    -- /src/ghorg/openedx/frontend-app-course-authoring ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-course-authoring@0.1.0: https://registry.npmjs.org/@edx/frontend-app-course-authoring/0.1.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1629/1629
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1072/1072
+    1629 deps, 1072 urls, 968 real urls
+    -- /src/ghorg/openedx/frontend-app-discussions ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-discussions@0.1.0: https://registry.npmjs.org/@edx/frontend-app-discussions/0.1.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1597/1597
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1010/1010
+    1597 deps, 1010 urls, 912 real urls
+    -- /src/ghorg/openedx/frontend-app-ecommerce ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-ecommerce@0.1.0: https://registry.npmjs.org/@edx/frontend-app-ecommerce/0.1.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1695/1695
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1122/1122
+    1695 deps, 1122 urls, 1006 real urls
+    -- /src/ghorg/openedx/frontend-app-gradebook ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-gradebook@1.6.0: https://registry.npmjs.org/@edx/frontend-app-gradebook/1.6.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1980/1980
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1273/1273
+    1980 deps, 1273 urls, 1118 real urls
+    -- /src/ghorg/openedx/frontend-app-learner-dashboard ----------
+    Checking JavaScript dependencies
+    @edx/frontend-component-footer@1.0.0-semantically-released: https://registry.npmjs.org/@edx/frontend-component-footer/1.0.0-semantically-released -> 404
+    @edx/frontend-app-learner-dashboard@0.0.1: https://registry.npmjs.org/@edx/frontend-app-learner-dashboard/0.0.1 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1917/1917
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1279/1279
+    1917 deps, 1279 urls, 1148 real urls
+    -- /src/ghorg/openedx/frontend-app-learner-record ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-learner-record@0.1.0: https://registry.npmjs.org/@edx/frontend-app-learner-record/0.1.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1527/1527
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 952/952
+    1527 deps, 952 urls, 866 real urls
+    -- /src/ghorg/openedx/frontend-app-learning ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-learning@1.0.0-semantically-released: https://registry.npmjs.org/@edx/frontend-app-learning/1.0.0-semantically-released -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1712/1712
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1073/1073
+    1712 deps, 1073 urls, 861 real urls
+    -- /src/ghorg/openedx/frontend-app-ora-grading ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-ora-grading@0.0.1: https://registry.npmjs.org/@edx/frontend-app-ora-grading/0.0.1 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1902/1902
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1234/1234
+    1902 deps, 1234 urls, 1115 real urls
+    -- /src/ghorg/openedx/frontend-app-payment ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-payment@0.1.0: https://registry.npmjs.org/@edx/frontend-app-payment/0.1.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1518/1518
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 989/989
+    1518 deps, 989 urls, 904 real urls
+    -- /src/ghorg/openedx/frontend-app-profile ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-profile@1.0.0-semantically-released: https://registry.npmjs.org/@edx/frontend-app-profile/1.0.0-semantically-released -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1575/1575
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1013/1013
+    1575 deps, 1013 urls, 923 real urls
+    -- /src/ghorg/openedx/frontend-app-publisher ----------
+    Checking JavaScript dependencies
+    edx-frontend-app-publisher@0.1.0: https://registry.npmjs.org/edx-frontend-app-publisher/0.1.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1616/1616
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1071/1071
+    1616 deps, 1071 urls, 952 real urls
+    -- /src/ghorg/openedx/frontend-app-support-tools ----------
+    Checking JavaScript dependencies
+    @edx/frontend-app-support@0.1.0: https://registry.npmjs.org/@edx/frontend-app-support/0.1.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1683/1683
+    Couldn't fetch github.com:samccone/chrome-trace-event: No connection adapters were found for 'github.com:samccone/chrome-trace-event'
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1150/1150
+    1683 deps, 1150 urls, 994 real urls
+    -- /src/ghorg/openedx/frontend-template-application ----------
+    Checking JavaScript dependencies
+    @edx/frontend-template-application@0.1.0: https://registry.npmjs.org/@edx/frontend-template-application/0.1.0 -> 404
+    Getting npm URLs     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1378/1378
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 851/851
+    1378 deps, 851 urls, 782 real urls
+    -- /src/ghorg/openedx/license-manager ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    No repo URL in files/click_didyoumean-0.3.0-py3-none-any.whl
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 89/89
+    Repo URL is UNKNOWN in files/pyjwkest-1.4.2.tar.gz
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 9/9
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 96/96
+    -- /src/ghorg/openedx/openedx-demo-course ----------
+    -- /src/ghorg/openedx/openedx-test-course ----------
+    -- /src/ghorg/openedx/repo-tools ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 82/82
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 6/6
+    Couldn't fetch http://trevp.net/tlslite/: ('Connection aborted.', ConnectionResetError(54, 'Connection reset by peer'))
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 87/87
+    -- /src/ghorg/openedx/testeng-ci ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 20/20
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 1/1
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 21/21
+    -- /src/ghorg/openedx/tubular ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 62/62
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 13/13
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 75/75
+    -- /src/ghorg/openedx/xqueue ----------
+    Checking Python dependencies
+    Creating venv
+    Downloading packages
+    Examining wheels     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 34/34
+    Examining tar.gz     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 2/2
+    Getting real URLs    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 36/36
+    == DONE ==============
+    Second-party:
+    https://github.com/edx/brand-edx.org
+    https://github.com/edx/braze-client
+    https://github.com/edx/edx-name-affirmation
+    https://github.com/edx/frontend-component-footer-edx
+    https://github.com/edx/getsmarter-api-clients
+    https://github.com/edx/learner-pathway-progress
+    https://github.com/edx/new-relic-source-map-webpack-plugin
+    https://github.com/edx/outcome-surveys
+    https://github.com/edx/ux-pattern-library
+    https://github.com/mitodl/edx-sga
+    https://github.com/open-craft/xblock-poll

--- a/maintainer_reports/graphql_queries.py
+++ b/maintainer_reports/graphql_queries.py
@@ -1,10 +1,10 @@
-_REPOS_ = "repo:openedx/DoneXBlock repo:openedx/RateXBlock repo:openedx/XBlock repo:openedx/blockstore repo:openedx/brand-openedx repo:openedx/codejail repo:openedx/configuration repo:openedx/course-discovery repo:openedx/credentials repo:openedx/cs_comments_service repo:openedx/devstack repo:openedx/docs.openedx.org repo:openedx/ecommerce repo:openedx/ecommerce-worker repo:openedx/edx-ace repo:openedx/edx-analytics-dashboard repo:openedx/edx-analytics-data-api repo:openedx/edx-analytics-pipeline repo:openedx/edx-app-android repo:openedx/edx-cookiecutters repo:openedx/edx-developer-docs repo:openedx/edx-documentation repo:openedx/edx-notes-api repo:openedx/edx-ora2 repo:openedx/edx-platform repo:openedx/edx-proctoring repo:openedx/edx-rest-api-client repo:openedx/edx-search repo:openedx/edx-toggles repo:openedx/enterprise-catalog repo:openedx/event-routing-backends repo:openedx/frontend-app-account repo:openedx/frontend-app-admin-portal repo:openedx/frontend-app-authn repo:openedx/frontend-app-course-authoring repo:openedx/frontend-app-discussions repo:openedx/frontend-app-ecommerce repo:openedx/frontend-app-gradebook repo:openedx/frontend-app-learning repo:openedx/frontend-app-payment repo:openedx/frontend-app-profile repo:openedx/frontend-app-program-console repo:openedx/frontend-app-publisher repo:openedx/frontend-app-support-tools repo:openedx/frontend-build repo:openedx/frontend-component-footer repo:openedx/frontend-component-header repo:openedx/frontend-platform repo:openedx/frontend-template-application repo:openedx/license-manager repo:openedx/mdrst repo:openedx/open-edx-proposals repo:openedx/openedx-conference-website repo:openedx/openedx-demo-course repo:openedx/openedx-events repo:openedx/openedx-filters repo:openedx/openedx-i18n repo:openedx/paragon repo:openedx/taxonomy-connector repo:openedx/xblock-drag-and-drop-v2 repo:openedx/xblock-lti-consumer repo:openedx/xqueue repo:openedx/frontend-app-library-authoring repo:openedx/frontend-app-learner-record repo:openedx/frontend-app-authn  repo:openedx/django-config-models repo:openedx/edx-bulk-grades repo:openedx/edx-django-utils repo:openedx/edx-val repo:openedx/frontend-app-discussions  repo:openedx/frontend-app-ora-grading repo:openedx/xblock-sdk repo:openedx/xblock-utils"
+_REPOS_ = "repo:openedx/DoneXBlock repo:openedx/RateXBlock repo:openedx/XBlock repo:openedx/blockstore repo:openedx/brand-openedx repo:openedx/codejail repo:openedx/configuration repo:openedx/course-discovery repo:openedx/credentials repo:openedx/cs_comments_service repo:openedx/devstack repo:openedx/docs.openedx.org repo:openedx/edx-ace repo:openedx/edx-app-android repo:openedx/edx-cookiecutters repo:openedx/edx-developer-docs repo:openedx/edx-documentation repo:openedx/edx-notes-api repo:openedx/edx-ora2 repo:openedx/edx-platform repo:openedx/edx-proctoring repo:openedx/edx-rest-api-client repo:openedx/edx-search repo:openedx/edx-toggles repo:openedx/enterprise-catalog repo:openedx/event-routing-backends repo:openedx/frontend-app-account repo:openedx/frontend-app-admin-portal repo:openedx/frontend-app-authn repo:openedx/frontend-app-course-authoring repo:openedx/frontend-app-discussions repo:openedx/frontend-app-ecommerce repo:openedx/frontend-app-gradebook repo:openedx/frontend-app-learning repo:openedx/frontend-app-payment repo:openedx/frontend-app-profile repo:openedx/frontend-app-program-console repo:openedx/frontend-app-publisher repo:openedx/frontend-app-support-tools repo:openedx/frontend-build repo:openedx/frontend-component-footer repo:openedx/frontend-component-header repo:openedx/frontend-platform repo:openedx/frontend-template-application repo:openedx/license-manager repo:openedx/mdrst repo:openedx/open-edx-proposals repo:openedx/openedx-conference-website repo:openedx/openedx-demo-course repo:openedx/openedx-events repo:openedx/openedx-filters repo:openedx/openedx-i18n repo:openedx/paragon repo:openedx/taxonomy-connector repo:openedx/xblock-drag-and-drop-v2 repo:openedx/xblock-lti-consumer repo:openedx/xqueue repo:openedx/frontend-app-library-authoring repo:openedx/frontend-app-learner-record repo:openedx/frontend-app-authn  repo:openedx/django-config-models repo:openedx/edx-bulk-grades repo:openedx/edx-django-utils repo:openedx/edx-val repo:openedx/frontend-app-discussions  repo:openedx/frontend-app-ora-grading repo:openedx/xblock-sdk repo:openedx/xblock-utils"
 
-_TYPE_="pr"
-_STATE_="closed"
-_QUERY_= f"{_REPOS_} is:{_TYPE_} is:{_STATE_} closed:_RANGE_"
+_TYPE_ = "pr"
+_STATE_ = "closed"
+_QUERY_ = f"{_REPOS_} is:{_TYPE_} is:{_STATE_} closed:_RANGE_"
 
-CLOSED_ISSUE_QUERY="""
+CLOSED_ISSUE_QUERY = """
 {
   search(first: 75, after: _END_CURSOR_, query: "_QUERY_", type: ISSUE) {
     pageInfo {
@@ -25,7 +25,7 @@ CLOSED_ISSUE_QUERY="""
           login
         }
         mergedBy {
-         login 
+         login
         }
         permalink
         createdAt
@@ -57,15 +57,14 @@ CLOSED_ISSUE_QUERY="""
     }
   }
 }
-""".replace("_QUERY_",_QUERY_)
+""".replace("_QUERY_", _QUERY_)
 
 
+_TYPE_ = "pr"
+_STATE_ = "open"
+_OPEN_QUERY_ = f"{_REPOS_} is:{_TYPE_} is:{_STATE_}"
 
-_TYPE_="pr"
-_STATE_="open"
-_OPEN_QUERY_= f"{_REPOS_} is:{_TYPE_} is:{_STATE_}"
-
-OPEN_ISSUE_QUERY="""
+OPEN_ISSUE_QUERY = """
 {
   search(first: 75, after: _END_CURSOR_, query: "_OPEN_QUERY_", type: ISSUE) {
     pageInfo {
@@ -86,7 +85,7 @@ OPEN_ISSUE_QUERY="""
           login
         }
         mergedBy {
-         login 
+         login
         }
         permalink
         createdAt
@@ -118,7 +117,7 @@ OPEN_ISSUE_QUERY="""
     }
   }
 }
-""".replace("_OPEN_QUERY_",_OPEN_QUERY_)
+""".replace("_OPEN_QUERY_", _OPEN_QUERY_)
 
 
 ISSUES_ONLY_QUERY = """
@@ -170,7 +169,7 @@ REPOSITORY_QUERY = """
           startCursor
           hasNextPage
           endCursor
-      } 
+      }
       nodes {
         ... on Repository {
           name
@@ -222,4 +221,3 @@ REPOSITORY_QUERY = """
     }
   }
 """
-


### PR DESCRIPTION
Part of https://github.com/openedx/public-engineering/issues/271 . I also included the old ecommerce repos and fixed some readme formatting that I noticed looked broken.