### PR TITLE
feat: add repo check to re-enable disabled workflows

### DIFF
--- a/edx_repo_tools/repo_checks/repo_checks.py
+++ b/edx_repo_tools/repo_checks/repo_checks.py
@@ -1225,6 +1225,9 @@ class EnsureWorkflowsEnabled(Check):
     """
 
     DISABLED_STATES = {"disabled_inactivity", "disabled_fork"}
+    # Preserve workflows that have been manually disabled to avoid overriding
+    # explicit administrative decisions.
+    DISABLED_MANUALLY_STATE = "disabled_manually"
 
     def __init__(self, api: GhApi, org: str, repo: str):
         super().__init__(api, org, repo)
@@ -1237,13 +1240,15 @@ class EnsureWorkflowsEnabled(Check):
         )
 
     def check(self) -> tuple[bool, str]:
-        response = self.api.actions.list_repo_workflows(
-            owner=self.org_name,
-            repo=self.repo_name,
-            per_page=100,
-        )
+        # list_repo_workflows returns {total_count, workflows} rather than a
+        # flat list, so all_paged_items cannot be used directly. We wrap it to
+        # extract just the workflows list, which all_paged_items expects.
+        def _list_workflows_page(**kwargs):
+            return self.api.actions.list_repo_workflows(**kwargs).workflows
+
+        all_workflows = list(all_paged_items(_list_workflows_page, owner=self.org_name, repo=self.repo_name))
         self.disabled_workflows = [
-            w for w in response.workflows if w.state in self.DISABLED_STATES
+            w for w in all_workflows if w.state in self.DISABLED_STATES
         ]
 
         if self.disabled_workflows:
@@ -1252,10 +1257,12 @@ class EnsureWorkflowsEnabled(Check):
                 False,
                 f"Some workflows are disabled:\n\t\t" + "\n\t\t".join(names),
             )
-        manually_disabled = [w for w in response.workflows if w.state == "disabled_manually"]
-        msg = f"All {response.total_count} workflows are enabled."
+        manually_disabled = [w for w in all_workflows if w.state == self.DISABLED_MANUALLY_STATE]
+        total = len(all_workflows)
+        enabled_count = total - len(manually_disabled)
+        msg = f"All {total} workflows are enabled."
         if manually_disabled:
-            msg = f"{response.total_count} workflows are enabled ({len(manually_disabled)} manually disabled)."
+            msg = f"{enabled_count} of {total} workflows are enabled ({len(manually_disabled)} manually disabled)."
         return (True, msg)
 
     def dry_run(self):

--- a/edx_repo_tools/repo_checks/repo_checks.py
+++ b/edx_repo_tools/repo_checks/repo_checks.py
@@ -1214,11 +1214,17 @@ class EnsureNoOutsideCollaborators(Check):
 class EnsureWorkflowsEnabled(Check):
     """
     Cron workflows and others can be automatically disabled by GitHub for various
-    reasons (e.g. inactivity on a forked repo). This check finds all disabled
-    workflows in a repo and re-enables them.
+    reasons (e.g. inactivity on a forked repo). This check finds all workflows
+    disabled due to inactivity or fork status and re-enables them.
+
+    Only workflows with state `disabled_inactivity` or `disabled_fork` are
+    re-enabled. Workflows disabled manually (`disabled_manually`) are left
+    untouched to avoid overriding intentional admin decisions.
 
     See: https://github.com/orgs/community/discussions/59547
     """
+
+    DISABLED_STATES = {"disabled_inactivity", "disabled_fork"}
 
     def __init__(self, api: GhApi, org: str, repo: str):
         super().__init__(api, org, repo)
@@ -1234,8 +1240,11 @@ class EnsureWorkflowsEnabled(Check):
         response = self.api.actions.list_repo_workflows(
             owner=self.org_name,
             repo=self.repo_name,
+            per_page=100,
         )
-        self.disabled_workflows = [w for w in response.workflows if w.state != "active"]
+        self.disabled_workflows = [
+            w for w in response.workflows if w.state in self.DISABLED_STATES
+        ]
 
         if self.disabled_workflows:
             names = [w.name for w in self.disabled_workflows]
@@ -1243,8 +1252,11 @@ class EnsureWorkflowsEnabled(Check):
                 False,
                 f"Some workflows are disabled:\n\t\t" + "\n\t\t".join(names),
             )
-        names = [w.name for w in response.workflows]
-        return (True, "All workflows are enabled:\n\t\t" + "\n\t\t".join(names))
+        manually_disabled = [w for w in response.workflows if w.state == "disabled_manually"]
+        msg = f"All {response.total_count} workflows are enabled."
+        if manually_disabled:
+            msg = f"{response.total_count} workflows are enabled ({len(manually_disabled)} manually disabled)."
+        return (True, msg)
 
     def dry_run(self):
         return self.fix(dry_run=True)
@@ -1253,11 +1265,15 @@ class EnsureWorkflowsEnabled(Check):
         steps = []
         for workflow in self.disabled_workflows:
             if not dry_run:
-                self.api.actions.enable_workflow(
-                    owner=self.org_name,
-                    repo=self.repo_name,
-                    workflow_id=workflow.id,
-                )
+                try:
+                    self.api.actions.enable_workflow(
+                        owner=self.org_name,
+                        repo=self.repo_name,
+                        workflow_id=workflow.id,
+                    )
+                except HTTP4xxClientError as e:
+                    steps.append(f"Failed to enable workflow `{workflow.name}` (id: {workflow.id}): {e}")
+                    continue
             steps.append(f"Enabled workflow `{workflow.name}` (id: {workflow.id})")
         return steps
 

--- a/edx_repo_tools/repo_checks/repo_checks.py
+++ b/edx_repo_tools/repo_checks/repo_checks.py
@@ -1210,6 +1210,58 @@ class EnsureNoOutsideCollaborators(Check):
         return steps
 
 
+@Check.register
+class EnsureWorkflowsEnabled(Check):
+    """
+    Cron workflows and others can be automatically disabled by GitHub for various
+    reasons (e.g. inactivity on a forked repo). This check finds all disabled
+    workflows in a repo and re-enables them.
+
+    See: https://github.com/orgs/community/discussions/59547
+    """
+
+    def __init__(self, api: GhApi, org: str, repo: str):
+        super().__init__(api, org, repo)
+        self.disabled_workflows = []
+
+    def is_relevant(self) -> bool:
+        return (
+            not is_security_private_fork(self.api, self.org_name, self.repo_name)
+            and not is_empty(self.api, self.org_name, self.repo_name)
+        )
+
+    def check(self) -> tuple[bool, str]:
+        workflows = list(all_paged_items(
+            self.api.actions.list_repo_workflows,
+            owner=self.org_name,
+            repo=self.repo_name,
+        ))
+        self.disabled_workflows = [w for w in workflows if w.state != "active"]
+
+        if self.disabled_workflows:
+            names = [w.name for w in self.disabled_workflows]
+            return (
+                False,
+                f"Some workflows are disabled:\n\t\t" + "\n\t\t".join(names),
+            )
+        return (True, "All workflows are enabled.")
+
+    def dry_run(self):
+        return self.fix(dry_run=True)
+
+    def fix(self, dry_run=False):
+        steps = []
+        for workflow in self.disabled_workflows:
+            if not dry_run:
+                self.api.actions.enable_workflow(
+                    owner=self.org_name,
+                    repo=self.repo_name,
+                    workflow_id=workflow.id,
+                )
+            steps.append(f"Enabled workflow `{workflow.name}` (id: {workflow.id})")
+        return steps
+
+
 @click.command()
 @click.option(
     "--github-token",

--- a/edx_repo_tools/repo_checks/repo_checks.py
+++ b/edx_repo_tools/repo_checks/repo_checks.py
@@ -1231,12 +1231,11 @@ class EnsureWorkflowsEnabled(Check):
         )
 
     def check(self) -> tuple[bool, str]:
-        workflows = list(all_paged_items(
-            self.api.actions.list_repo_workflows,
+        response = self.api.actions.list_repo_workflows(
             owner=self.org_name,
             repo=self.repo_name,
-        ))
-        self.disabled_workflows = [w for w in workflows if w.state != "active"]
+        )
+        self.disabled_workflows = [w for w in response.workflows if w.state != "active"]
 
         if self.disabled_workflows:
             names = [w.name for w in self.disabled_workflows]
@@ -1244,7 +1243,8 @@ class EnsureWorkflowsEnabled(Check):
                 False,
                 f"Some workflows are disabled:\n\t\t" + "\n\t\t".join(names),
             )
-        return (True, "All workflows are enabled.")
+        names = [w.name for w in response.workflows]
+        return (True, "All workflows are enabled:\n\t\t" + "\n\t\t".join(names))
 
     def dry_run(self):
         return self.fix(dry_run=True)

--- a/tests/test_repo_checks.py
+++ b/tests/test_repo_checks.py
@@ -108,12 +108,16 @@ def make_workflow(name, state, workflow_id=1):
 def make_workflows_api(workflows):
     """
     Make a mock API that returns the given workflows from list_repo_workflows.
+    Simulates pagination: page 1 returns the workflows, subsequent pages are empty.
     """
     api = MagicMock()
-    response = MagicMock()
-    response.workflows = workflows
-    response.total_count = len(workflows)
-    api.actions.list_repo_workflows.return_value = response
+
+    def side_effect(**kwargs):
+        response = MagicMock()
+        response.workflows = workflows if kwargs.get("page", 1) == 1 else []
+        return response
+
+    api.actions.list_repo_workflows.side_effect = side_effect
     return api
 
 

--- a/tests/test_repo_checks.py
+++ b/tests/test_repo_checks.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from fastcore.net import HTTP4xxClientError
+
 from edx_repo_tools.repo_checks import repo_checks
 
 
@@ -90,3 +92,110 @@ class TestLabelsCheck:
         assert call_args == expected_call
         assert not api.issues.create_label.called
         assert api.issues.update_label.called
+
+
+def make_workflow(name, state, workflow_id=1):
+    """
+    Quickly make a basic workflow object to return via the API.
+    """
+    w = MagicMock()
+    w.name = name
+    w.state = state
+    w.id = workflow_id
+    return w
+
+
+def make_workflows_api(workflows):
+    """
+    Make a mock API that returns the given workflows from list_repo_workflows.
+    """
+    api = MagicMock()
+    response = MagicMock()
+    response.workflows = workflows
+    response.total_count = len(workflows)
+    api.actions.list_repo_workflows.return_value = response
+    return api
+
+
+class TestEnsureWorkflowsEnabled:
+    def test_check_all_active(self):
+        api = make_workflows_api([make_workflow("CI", "active"), make_workflow("Lint", "active")])
+        check_cls = repo_checks.EnsureWorkflowsEnabled(api, "test_org", "test_repo")
+        # Make sure that the check returns True when all workflows are active.
+        assert check_cls.check()[0] == True
+
+    def test_check_disabled_inactivity(self):
+        api = make_workflows_api([make_workflow("CI", "active"), make_workflow("Upgrade", "disabled_inactivity", 42)])
+        check_cls = repo_checks.EnsureWorkflowsEnabled(api, "test_org", "test_repo")
+        # The check should be false because a workflow is disabled due to inactivity.
+        assert check_cls.check()[0] == False
+
+    def test_check_disabled_fork(self):
+        api = make_workflows_api([make_workflow("Upgrade", "disabled_fork", 99)])
+        check_cls = repo_checks.EnsureWorkflowsEnabled(api, "test_org", "test_repo")
+        # The check should be false because a workflow is disabled due to fork status.
+        assert check_cls.check()[0] == False
+
+    def test_check_disabled_manually_ignored(self):
+        api = make_workflows_api([make_workflow("CI", "active"), make_workflow("Secret", "disabled_manually")])
+        check_cls = repo_checks.EnsureWorkflowsEnabled(api, "test_org", "test_repo")
+        # Manually disabled workflows should not be flagged.
+        assert check_cls.check()[0] == True
+
+    def test_fix_enables_disabled_workflows(self):
+        api = make_workflows_api([make_workflow("Upgrade", "disabled_inactivity", 42)])
+        check_cls = repo_checks.EnsureWorkflowsEnabled(api, "test_org", "test_repo")
+        check_cls.check()
+        steps = check_cls.fix()
+        # fix() should call enable_workflow with the correct arguments.
+        assert api.actions.enable_workflow.call_args == call(
+            owner="test_org",
+            repo="test_repo",
+            workflow_id=42,
+        )
+        assert len(steps) == 1
+        assert "Upgrade" in steps[0]
+
+    def test_dry_run_does_not_call_enable(self):
+        api = make_workflows_api([make_workflow("Upgrade", "disabled_inactivity", 42)])
+        check_cls = repo_checks.EnsureWorkflowsEnabled(api, "test_org", "test_repo")
+        check_cls.check()
+        check_cls.dry_run()
+        # dry_run() should not make any changes to GitHub.
+        assert not api.actions.enable_workflow.called
+
+    def test_is_relevant_false_for_security_fork(self):
+        api = MagicMock()
+        api.repos.get.return_value = MagicMock(private=True, default_branch="main")
+        check_cls = repo_checks.EnsureWorkflowsEnabled(api, "test_org", "test_repo-ghsa-1234-5678-9012")
+        assert check_cls.is_relevant() == False
+
+    @patch("edx_repo_tools.repo_checks.repo_checks.is_empty", return_value=True)
+    def test_is_relevant_false_for_empty_repo(self, _):
+        api = MagicMock()
+        api.repos.get.return_value = MagicMock(private=False, default_branch="main")
+        check_cls = repo_checks.EnsureWorkflowsEnabled(api, "test_org", "test_repo")
+        assert check_cls.is_relevant() == False
+
+    def test_is_relevant_true_for_normal_repo(self):
+        api = MagicMock()
+        api.repos.get.return_value = MagicMock(private=False, default_branch="main")
+        check_cls = repo_checks.EnsureWorkflowsEnabled(api, "test_org", "test_repo")
+        assert check_cls.is_relevant() == True
+
+    def test_fix_continues_on_api_error(self):
+        api = make_workflows_api([
+            make_workflow("Failing", "disabled_inactivity", 1),
+            make_workflow("Upgrade", "disabled_inactivity", 2),
+        ])
+        api.actions.enable_workflow.side_effect = [
+            HTTP4xxClientError("url", 422, "Unprocessable Entity", {}, None),
+            None,
+        ]
+        check_cls = repo_checks.EnsureWorkflowsEnabled(api, "test_org", "test_repo")
+        check_cls.check()
+        steps = check_cls.fix()
+        # fix() should attempt all workflows even if one fails.
+        assert api.actions.enable_workflow.call_count == 2
+        assert any("Failed" in s for s in steps)
+        assert any("Upgrade" in s for s in steps)


### PR DESCRIPTION
## Description:

GitHub can automatically disable workflows (e.g. cron jobs on inactive forked repos). The new EnsureWorkflowsEnabled check detects all non-active workflows in a repo and re-enables them.

See: https://github.com/orgs/community/discussions/59547
Ticket: https://github.com/openedx/repo-tools/issues/596

## How to test  
Details can be found here https://github.com/openedx/repo-tools/blob/master/edx_repo_tools/repo_checks/README.rst

## Testing results

- [x] Testing disabled workflow list output

**command**
```
uv run --extra repo_checks repo_checks --dry-run -c EnsureWorkflowsEnabled -r forum
```

**Output on terminal**

<img width="1498" height="212" alt="Screenshot 2026-06-01 at 12 51 16 PM" src="https://github.com/user-attachments/assets/54866648-b5a7-4c61-b5f2-259bf8df93c2" />

**Verification of output on github** 

<img width="1512" height="672" alt="Screenshot 2026-06-01 at 12 51 05 PM" src="https://github.com/user-attachments/assets/e61bc939-ad8b-4c87-9b87-065666a20e75" />

---------------------------------------


- [x] Testing to re-enable  workflow 

**command**
```
uv run --extra repo_checks repo_checks --no-dry-run -c EnsureWorkflowsEnabled -r forum
```

<img width="1497" height="190" alt="Screenshot 2026-06-01 at 12 52 42 PM" src="https://github.com/user-attachments/assets/cf148d51-5a07-4631-a607-8e5e64860c83" />


Verify that all workflows have been re-enabled

<img width="1497" height="285" alt="Screenshot 2026-06-01 at 12 53 07 PM" src="https://github.com/user-attachments/assets/cf3c3420-c8c9-479f-9432-328ca94491a5" />

<img width="1508" height="578" alt="Screenshot 2026-06-01 at 12 52 31 PM" src="https://github.com/user-attachments/assets/218e6e52-95af-4b03-8423-b8729f9bbaf5" />
