### PR TITLE
Fix support window issue-bot Invalid inputs failure

### DIFF
--- a/.github/workflows/support-window-issue-creator.yml
+++ b/.github/workflows/support-window-issue-creator.yml
@@ -14,6 +14,7 @@ jobs:
         uses: imjohnbo/issue-bot@3188c6ce06249206709d3b1f274d0d4c5a521601 # v3.4.5
         with:
           assignees: "usamasadiq"
+          labels: "support-window"
           close-previous: true
           title: "Support Window Update"
           body: |


### PR DESCRIPTION
## Summary
- The `Support Windows Issue Creater` workflow has been failing every quarterly run with `Error: Invalid inputs`.
- `imjohnbo/issue-bot@3188c6c` is already pinned to the latest release (v3.4.5) — this is not a stale-version issue.
- That version's input validation requires a non-empty `labels` input whenever `close-previous: true` is set, and the workflow never set `labels`, so the action always threw before doing anything.
- Adds `labels: "support-window"` so the required-inputs check passes and `close-previous` can correctly find/close the prior issue by label.

## Test plan
- [ ] Confirm the next scheduled run of `.github/workflows/support-window-issue-creator.yml` (or a manual re-run) creates the issue without an `Invalid inputs` error
- [ ] Note: the first run after this fix won't find a previous issue to close (existing open issues don't have the `support-window` label yet); subsequent runs will close-previous correctly