### PR TITLE
Allow manual trigger of support window issue creator workflow

### DIFF
--- a/.github/workflows/support-window-issue-creator.yml
+++ b/.github/workflows/support-window-issue-creator.yml
@@ -2,6 +2,7 @@ name: Support Windows Issue Creater
 on:
   schedule:
     - cron: 0 0 1 */3 *
+  workflow_dispatch:
 
 jobs:
   create_issue:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to `.github/workflows/support-window-issue-creator.yml` so it can be run on demand from the Actions tab, in addition to its existing quarterly cron schedule.
- Follow-up to #727 — useful for verifying that fix without waiting for the next scheduled run, and generally for creating the issue ad hoc when needed.

## Test plan
- [ ] From the Actions tab, manually run "Support Windows Issue Creater" and confirm it creates the issue successfully