### PR TITLE
Update barcalendar.py to reflect current openedx-supported versions

### DIFF
--- a/barcalendar.py
+++ b/barcalendar.py
@@ -406,9 +406,9 @@ CURRENT = {
     "Open edX": parse_version_name(versions['OPENEDX_COMMON_VERSION']),
     "Python": "3.11",
     "Django": "5.2",
-    "Ubuntu": "24.04",
+    "Ubuntu": "22.04",
     "Node": "24",
-    "React": "16",
+    "React": "18",
     "Mongo": parse_version_number(versions['DOCKER_IMAGE_MONGODB']),
     "MySQL": parse_version_number(versions['DOCKER_IMAGE_MYSQL']),
     "Elasticsearch": "7.17",
@@ -550,7 +550,7 @@ ubuntu_nicks = {                        # https://wiki.ubuntu.com/Releases
     #'16.04': 'Xenial Xerus',
     #'18.04': 'Bionic Beaver',
     #'20.04': 'Focal Fossa',
-    #'22.04': 'Jammy Jellyfish',
+    '22.04': 'Jammy Jellyfish',
     '24.04': 'Noble Numbat',
     '25.04': "Plucky Puffin",
 }
@@ -589,6 +589,7 @@ node_releases = [
     #('20', 2023, 4, 2026, 4),
     ('22', 2024, 4, 2027, 4),
     ('24', 2025, 5, 2028, 4),
+    ('26', 2026, 5, 2029, 4),
 ]
 for name, syear, smonth, eyear, emonth in node_releases:
     eyear, emonth = validate_version_date("NodeJS", name, eyear, emonth)
@@ -661,7 +662,7 @@ mysql_releases = [
     # ('8.0', 2018, 4, 2026, 4),
     # ('8.1', 2023, 6, 2023, 10),
     ('8.4', 2024, 4, 2032, 4),
-    ('9.4', 2025, 7, 3000, 1),
+    ('9.7', 2026, 4, 2034, 4),
 ]
 for name, syear, smonth, eyear, emonth in mysql_releases:
     eyear, emonth = validate_version_date("MySQL", name, eyear, emonth)
@@ -689,7 +690,7 @@ es_releases = [
     # ('7.13', 2021, 5, 2022, 11),
     ('7.17', 2022, 2, 2026, 1),
     ('8.17', 2024, 12, 2027, 7),
-    ('9.0', 2025, 4, 2028, 10),
+    ('9.0', 2025, 4, 2027, 10),   # End of Maintenance Term; End of Support is TBD pending 10.0
 ]
 for name, syear, smonth, eyear, emonth in es_releases:
     eyear, emonth = validate_version_date("elasticsearch", name, eyear, emonth)
@@ -703,16 +704,15 @@ for name, syear, smonth, eyear, emonth in es_releases:
 cal.gap_line()
 
 # Redis
-cal.section_note("https://docs.redis.com/latest/rs/administering/product-lifecycle/#endoflife-schedule")
-# https://endoflife.date/redis
+cal.section_note("https://endoflife.date/redis")
 redis_releases = [
     # ('6.0', 2020, 5, 2023, 8),
     # ('6.2', 2021, 8, 2024, 8),
     # ('7.0', 2022, 4, 2024, 7),
     # ('7.2', 2023, 8, 2024, 8),
     ('7.4', 2024, 7, 2026, 11),
-    ('8.0', 2025, 5, 3000, 1),
-    ('8.2', 2025, 4, 3000, 1),
+    ('8.0', 2025, 5, 2026, 2),
+    ('8.2', 2025, 8, 2026, 5),
 ]
 for name, syear, smonth, eyear, emonth in redis_releases:
     eyear, emonth = validate_version_date("Redis", name, eyear, emonth)


### PR DESCRIPTION
## Description
Closes #729.

Verified every hardcoded version and EOL date in `barcalendar.py` against the actual dependencies used by the current Open edX release (release/ulmo.3, tutor v21.0.8) and against each section's cited authoritative source (endoflife.date, elastic.co, djangoproject.com, nodejs Release schedule).

Changes:
- Ubuntu: current version corrected from 24.04 to 22.04, matching the base image used by tutor v21.0.8. Uncommented the 22.04 nickname (Jammy Jellyfish) so it displays.
- React: current version corrected from 16 to 18, matching the version used by all current Open edX MFEs (frontend-app-learning, frontend-app-authoring, etc.) at ulmo.3. edx-platform's own package.json still pins React 16 for legacy code, but MFEs are the actual current frontend stack.
- MySQL: replaced the stale, already-EOL 9.4 innovation release with 9.7, the current LTS (released April 2026, EOL April 2034).
- Elasticsearch: fixed the 9.0 end date, which was off by a year (2028-10 instead of the correct 2027-10 per elastic.co's published End of Maintenance Term).
- Redis: replaced incorrect "indefinite" EOL markers for 8.0 and 8.2 with their actual known EOL dates, and fixed 8.2's start date, which incorrectly predated 8.0's start date. Repointed the section note from a Redis Enterprise lifecycle page to the correct OSS source (endoflife.date/redis).
- Node: added the newly released Node 26 line as a forward-looking upgrade candidate.

Python (3.11) and Django (5.2) were checked and found to already be correct against the ulmo.3 release branch, no change needed there.

## Testing
Ran `barcalendar.py` before and after the change. After the fix, the only remaining validation warnings are expected ones: future Django/Ubuntu releases not yet published on endoflife.date, and Elasticsearch entries that intentionally follow elastic.co's official major-version support policy rather than endoflife.date's per-minor-version tracking (documented in the code).